### PR TITLE
osx tweak for standalone program generation

### DIFF
--- a/mir-bin-driver.c
+++ b/mir-bin-driver.c
@@ -23,7 +23,11 @@ static int read_byte (MIR_context_t ctx) {
 static struct lib {
   char *name;
   void *handler;
-} libs[] = {{"/lib64/libc.so.6", NULL}, {"/lib64/libm.so.6", NULL}};
+} libs[] = {
+#if !defined(__APPLE__)
+  {"/lib64/libc.so.6", NULL}, {"/lib64/libm.so.6", NULL}
+#endif
+};
 
 static void close_libs (void) {
   for (int i = 0; i < sizeof (libs) / sizeof (struct lib); i++)

--- a/mir-utils/README.md
+++ b/mir-utils/README.md
@@ -10,7 +10,7 @@ This directory contains some usefull utility:
   containing an array initialized by the MIR binary
 
   * You can generate a standalone program executing the MIR binary by
-    `cc -O2 -fno-tree-sra mir.o mir-gen.o mir-binary-driver.c -ldl`
+    `cc -O2 -fno-tree-sra mir.o mir-gen.o mir-bin-driver.c -ldl`
 
   * The program reads MIR binary from the array and execute it by
     interpreter (if you add `-DMIR_USE_INTERP` to the above


### PR DESCRIPTION
before
<img width="494" alt="Screen Shot 2020-01-25 at 00 26 05" src="https://user-images.githubusercontent.com/486807/73105207-70538a00-3f09-11ea-8813-3407e8c38f60.png">

after
<img width="587" alt="Screen Shot 2020-01-25 at 00 26 46" src="https://user-images.githubusercontent.com/486807/73105217-76496b00-3f09-11ea-987f-abba6573410d.png">

Also `clang` does not recognize `'-fno-tree-sra'` argument. Could we skip it?