### PR TITLE
WIN64 requires caller to allocate stack space for reg args.

### DIFF
--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -191,6 +191,9 @@ static void machinize_call (MIR_context_t ctx, MIR_insn_t call_insn) {
     nargs = VARR_LENGTH (MIR_var_t, proto->args);
     arg_vars = VARR_ADDR (MIR_var_t, proto->args);
   }
+#ifdef _WIN64
+  if (nargs > 4) mem_size = 32; /* spill space for register args */
+#endif
   if (call_insn->ops[1].mode != MIR_OP_REG && call_insn->ops[1].mode != MIR_OP_HARD_REG) {
     temp_op = MIR_new_reg_op (ctx, gen_new_temp_reg (ctx, MIR_T_I64, func));
     new_insn = MIR_new_insn (ctx, MIR_MOV, temp_op, call_insn->ops[1]);


### PR DESCRIPTION
I hope you don't mind me incrementally fixing WIN64 bits.