### PR TITLE
mir: Use __builtin___clear_cache instead of __clear_cache

### DIFF
--- a/mir.c
+++ b/mir.c
@@ -3391,7 +3391,7 @@ static code_holder_t *get_last_code_holder (MIR_context_t ctx, size_t size) {
 #ifndef __MIRC__
 void _MIR_flush_code_cache (void *start, void *bound) {
 #ifdef __GNUC__
-  __clear_cache (start, bound);
+  __builtin___clear_cache (start, bound);
 #endif
 }
 #endif


### PR DESCRIPTION
__clear_cache causes compiler error when using clang.
The official name for this builtin function is __builtin___clear_cache, GCC just provides __clear_cache as an alias. So this change has no functional change.

```
mir.c:3394:3: warning: implicit declaration of function '__clear_cache' is
      invalid in C99 [-Wimplicit-function-declaration]
  __clear_cache (start, bound);
```