### PR TITLE
Fix memory leak reported by ASAN. 

### DIFF
--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -2089,6 +2089,7 @@ static void define (c2m_ctx_t c2m_ctx) {
       error (c2m_ctx, id->pos, "macro definition of %s", name);
     } else {
       new_macro (c2m_ctx, id, params, repl);
+      params = NULL;
     }
   } else if (m->replacement == NULL) {
     error (c2m_ctx, id->pos, "standard macro %s redefinition", name);
@@ -2097,6 +2098,8 @@ static void define (c2m_ctx_t c2m_ctx) {
       error (c2m_ctx, id->pos, "different macro redefinition of %s", name);
     VARR_DESTROY (token_t, repl);
   }
+  if (params != NULL)
+    VARR_DESTROY(token_t, params);
 }
 
 #ifdef C2MIR_PREPRO_DEBUG


### PR DESCRIPTION
If params is not used in a new macro then it should be deallocated.

Signed-off-by: Dibyendu Majumdar <mobile@majumdar.org.uk>