### PR TITLE
fixed a problem with Small BLK in vararg on Linux about #136.

### DIFF
--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -11446,9 +11446,16 @@ static op_t gen (c2m_ctx_t c2m_ctx, node_t r, MIR_label_t true_label, MIR_label_
       if (op2.mir_op.mode == MIR_OP_MEM && op2.mir_op.u.mem.type == MIR_T_UNDEF)
         op2 = mem_to_address (c2m_ctx, op2, FALSE);
       if (type->mode == TM_STRUCT || type->mode == TM_UNION) {
-        MIR_append_insn (ctx, curr_func,
-                         MIR_new_insn (ctx, MIR_VA_STACK_ARG, op1.mir_op, op2.mir_op,
-                                       MIR_new_int_op (ctx, type_size (c2m_ctx, type))));
+        size_t ts = type_size (c2m_ctx, type);
+        if (ts <= 2 * 8) {
+          MIR_append_insn (ctx, curr_func,
+                          MIR_new_insn (ctx, MIR_VA_ARG, op1.mir_op, op2.mir_op,
+                                        MIR_new_mem_op (ctx, t, 0, 0, 0, 1)));
+        } else {
+          MIR_append_insn (ctx, curr_func,
+                          MIR_new_insn (ctx, MIR_VA_STACK_ARG, op1.mir_op, op2.mir_op,
+                                        MIR_new_int_op (ctx, ts)));
+        }
         op2 = op1;
       } else {
         MIR_append_insn (ctx, curr_func,


### PR DESCRIPTION
I might have found a root cause about #136. Could you check it?
I created a small patch to fix it.

I can't try it on an actual Linux, but I think it can be reproduced on it.

According to my investigation, should you use `va_arg` without dereference instead of `va_stack_arg` for the small struct which size is up to 16 bytes?
It is because the address of that values in calling seems to be stored on 64 bit registers.

I confirmed that problem is fixed by this patch, but I am sorry I can't confirm everything.
If there are some influences to other platforms or any other mechanism, please throw away this patch.

Thanks in advance.

The following is an additional investigation result for your confirmation.

### Details

Here is the differences between 2 blk sizes, which is 16 bytes and 20 bytes.
The following is just 16 bytes struct.

When the struct size is over 16 bytes, copy the value by blk.
But the size is 16 bytes or less, the address is passed by the register.

```
struct car {
	unsigned a, b, c, d;
};
---
foo:	func	i32, i32:i0_n, ...
	local	i64:fp, i64:I_0, i64:I_1, i64:I_2, i64:I_3, i64:I_4, i64:I_5, i64:I_6
	local	i64:u_7, i64:u_8
# 1 arg, 10 locals
	alloca	fp, 48
	add	I_0, fp, 16
	va_start	I_0
	add	I_3, fp, 48
	add	I_5, fp, 16
	va_arg	I_4, I_5, i64:0
	call	memcpy_p, memcpy, I_6, fp, I_4, 16
	adds	u_7, u32:(fp), u32:4(fp)
	adds	u_8, u_7, u32:8(fp)
	mov	i0_n, u_8
	ret	i0_n
	endfunc
	export	foo
main:	func	i32
	local	i64:fp, i64:I_0, i64:I_1, i64:i_2, i64:i_3, i64:I_4, i64:I_5, i64:I_6
# 0 args, 8 locals
	alloca	fp, 32
	mov	u32:16(fp), 1
	mov	u32:20(fp), 2
	mov	u32:24(fp), 3
	add	I_1, fp, 28
	call	memset_p, memset, I_0, I_1, 0, 4
	add	I_4, fp, 16
	mov	I_5, i64:(I_4)
	mov	I_6, i64:8(I_4)
	call	proto1, foo, i_3, 1, I_5, I_6
	call	proto0, printf, i_2, "car: %d\n\000", i_3
	ret	0
	endfunc
	export	main
	endmodule
```

The following is more than 16 bytes, it is actually 20 bytes.

```
struct car {
	unsigned a, b, c, d;
	char x;
};
---
foo:	func	i32, i32:i0_n, ...
	local	i64:fp, i64:I_0, i64:I_1, i64:I_2, i64:I_3, i64:I_4, i64:u_5, i64:u_6
# 1 arg, 8 locals
	alloca	fp, 64
	add	I_0, fp, 32
	va_start	I_0
	add	I_1, fp, 64
	add	I_3, fp, 32
	va_stack_arg	I_2, I_3, 20
	call	memcpy_p, memcpy, I_4, fp, I_2, 20
	adds	u_5, u32:(fp), u32:4(fp)
	adds	u_6, u_5, u32:8(fp)
	mov	i0_n, u_6
	ret	i0_n
	endfunc
	export	foo
main:	func	i32
	local	i64:fp, i64:I_0, i64:I_1, i64:i_2, i64:i_3, i64:I_4
# 0 args, 6 locals
	alloca	fp, 48
	mov	u32:20(fp), 1
	mov	u32:24(fp), 2
	mov	u32:28(fp), 3
	add	I_1, fp, 32
	call	memset_p, memset, I_0, I_1, 0, 5
	add	I_4, fp, 20
	call	proto1, foo, i_3, 1, blk:20(I_4)
	call	proto0, printf, i_2, "car: %d\n\000", i_3
	ret	0
	endfunc
	export	main
	endmodule
```
