### PR TITLE
Add missing MIR_get_global_item

### DIFF
--- a/mir.c
+++ b/mir.c
@@ -1464,6 +1464,16 @@ void MIR_finish_module (MIR_context_t ctx) {
   curr_module = NULL;
 }
 
+MIR_item_t MIR_get_global_item (MIR_context_t ctx, const char *name) {
+  for (MIR_item_t item = DLIST_HEAD (MIR_item_t, environment_module.items); item != NULL;
+       item = DLIST_NEXT (MIR_item_t, item)) {
+    if (item->item_type == MIR_import_item && strcmp (item->u.import_id, name) == 0) {
+      return item->ref_def;
+    }
+  }
+  return NULL;
+}
+
 static void setup_global (MIR_context_t ctx, const char *name, void *addr, MIR_item_t def) {
   MIR_item_t item, tab_item;
   MIR_module_t saved = curr_module;

--- a/mir.h
+++ b/mir.h
@@ -553,6 +553,7 @@ extern void MIR_read_with_func (MIR_context_t ctx, int (*const reader_func) (MIR
 extern void MIR_scan_string (MIR_context_t ctx, const char *str);
 #endif
 
+/* Get an exported item or an external function by its name */
 extern MIR_item_t MIR_get_global_item (MIR_context_t ctx, const char *name);
 extern void MIR_load_module (MIR_context_t ctx, MIR_module_t m);
 extern void MIR_load_external (MIR_context_t ctx, const char *name, void *addr);


### PR DESCRIPTION
Hi,

`MIR_get_global_item` was missing a definition, so I added it according to my best guess. That guess might be way off though, since I'm completely new to MIR. I also did not test if it works with forward definitions or re-exports.