### PR TITLE
Limit alloca size to 16KB on Windows.

### DIFF
--- a/sieve.c
+++ b/sieve.c
@@ -1,6 +1,12 @@
 void printf (const char *fmt, ...);
 void abort (void);
+#ifdef _WIN32
+#define SieveSize 16384
+#define Expected 1900
+#else
 #define SieveSize 819000
+#define Expected 65333
+#endif
 #define N_ITER 1000
 int sieve (int n) {
   long i, k, count, iter, prime;
@@ -22,6 +28,6 @@ int main (void) {
   int n = sieve (N_ITER);
 
   printf ("%d iterations of sieve for %d: result = %d\n", N_ITER, SieveSize, n);
-  if (n != 65333) abort ();
+  if (n != Expected) abort ();
   return 0;
 }


### PR DESCRIPTION
This is not a big problem, but the example of `sieve.c` crashes on Windows.

According to the PR of #134, the stack size seems to be limited on Windows.
Therefore after fixed it to 16KB only with Windows, it can make it work well.

I am sorry when you are busy.
This is just a small patch.
