### PR TITLE
docs: fix simple typo, caclulate -> calculate

### DIFF
--- a/mir-aarch64.c
+++ b/mir-aarch64.c
@@ -279,7 +279,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
 
   VARR_CREATE (uint8_t, code, 128);
   mir_assert (sizeof (long double) == 16);
-  for (size_t i = 0; i < nargs; i++) { /* caclulate offset for blk params */
+  for (size_t i = 0; i < nargs; i++) { /* calculate offset for blk params */
     type = arg_descs[i].type;
     if ((MIR_T_I8 <= type && type <= MIR_T_U64) || type == MIR_T_P || MIR_all_blk_type_p (type)) {
       if (MIR_blk_type_p (type) && (qwords = (arg_descs[i].size + 7) / 8) <= 2) {

--- a/mir-gen-aarch64.c
+++ b/mir-gen-aarch64.c
@@ -256,7 +256,7 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
     call_insn->ops[1] = temp_op;
     gen_add_insn_before (gen_ctx, call_insn, new_insn);
   }
-  for (size_t i = start; i < nops; i++) { /* caclulate offset for blk params */
+  for (size_t i = start; i < nops; i++) { /* calculate offset for blk params */
     if (i - start < nargs) {
       type = arg_vars[i - start].type;
     } else if (call_insn->ops[i].mode == MIR_OP_MEM) {


### PR DESCRIPTION
There is a small typo in mir-aarch64.c, mir-gen-aarch64.c.

Should read `calculate` rather than `caclulate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md