### PR TITLE
hex_value return -1 will make d1 d2 overflow

### DIFF
--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -1968,7 +1968,8 @@ static void out_insn (gen_ctx_t gen_ctx, MIR_insn_t insn, const char *replacemen
       && (insn->ops[1].mode == MIR_OP_INT || insn->ops[1].mode == MIR_OP_UINT))
     insn->ops[1].u.u = (insn->ops[1].u.u + 15) & -16;
   for (insn_str = replacement;; insn_str = p + 1) {
-    char ch, start_ch, d1, d2;
+    char ch, start_ch;
+    int d1, d2;
     int opcode0 = -1, opcode1 = -1, opcode2 = -1;
     int rex_w = -1, rex_r = -1, rex_x = -1, rex_b = -1, rex_0 = -1;
     int mod = -1, reg = -1, rm = -1;


### PR DESCRIPTION
Hi, vnmakarov:
  when I try to use MIR to compile my demo, I got a crash:
````
main_entry:     module
main:   func
        local   i64:I_0, i64:I_1, i64:I_2, i64:I_3
# 0 args, 4 locals
        alloca  I_0, 16
        mov     u64:(I_0), 10
        add     I_1, I_0, 8
        mov     u64:(I_1), 0
        alloca  I_2, 16
        mov     u64:(I_2), 10
        add     I_3, I_2, 8
        mov     u64:(I_3), 1
        call    PrintJSValue_proto, PrintJSValue, 100, blk1:16(I_0), blk1:16(I_2)
        endfunc
PrintJSValue_proto:     proto   i64:ctx, blk1:16(val1), blk1:16(val2)
        import  PrintJSValue
        endmodule
Assertion failed: (0), function out_insn, file jit/mir-gen-x86_64.c, line 2203.
[5]    94985 abort      ./jit-main
````
  This was caused by hex_value() may return -1, but d1 = hex_value(ch), and d1 is char,  it may be overflow, and d1 > 0 will return true.