### PR TITLE
Support statement expressions

### DIFF
--- a/c-tests/new/stmt-exprs.c
+++ b/c-tests/new/stmt-exprs.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+
+int f(int x) { return x; }
+
+int div(int a, int b) {
+    return f(({
+        if (b == 0) return 0; // testing return inside stmt expr
+        int res;
+        res = a / b;
+        goto skip; // testing goto inside stmt expr
+        res = 0;
+skip:
+        res;
+    }));
+}
+
+int main() {
+    assert(div(6, 2) == 3);
+    assert(div(1, 0) == 0);
+    return 0;
+}

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -483,6 +483,7 @@ expr : N_I | N_L | N_LL | N_U | N_UL | N_ULL | N_F | N_D | N_LD
      | N_DEREF_FIELD (expr, N_ID) | N_COND (expr, expr, expr)
      | N_COMPOUND_LITERAL (type_name, initializer) | N_CALL (expr, N_LIST:(expr)*)
      | N_GENERIC (expr, N_LIST:(N_GENERIC_ASSOC (type_name?, expr))+ )
+     | N_STMTEXPR (compound_stmt)
 label: N_CASE(expr) | N_CASE(expr,expr) | N_DEFAULT | N_LABEL(N_ID)
 stmt: compound_stmt | N_IF(N_LIST:(label)*, expr, stmt, stmt?)
     | N_SWITCH(N_LIST:(label)*, expr, stmt) | (N_WHILE|N_DO) (N_LIST:(label)*, expr, stmt)
@@ -562,7 +563,7 @@ static token_code_t FIRST_KW = T_BOOL, LAST_KW = T_WHILE;
 typedef enum {
   REP8 (NODE_EL, IGNORE, I, L, LL, U, UL, ULL, F),
   REP8 (NODE_EL, D, LD, CH, CH16, CH32, STR, STR16, STR32),
-  REP4 (NODE_EL, ID, COMMA, ANDAND, OROR),
+  REP5 (NODE_EL, ID, COMMA, ANDAND, OROR, STMTEXPR),
   REP8 (NODE_EL, EQ, NE, LT, LE, GT, GE, ASSIGN, BITWISE_NOT),
   REP8 (NODE_EL, NOT, AND, AND_ASSIGN, OR, OR_ASSIGN, XOR, XOR_ASSIGN, LSH),
   REP8 (NODE_EL, LSH_ASSIGN, RSH, RSH_ASSIGN, ADD, ADD_ASSIGN, SUB, SUB_ASSIGN, MUL),
@@ -3988,6 +3989,8 @@ static node_t try_arg_f (c2m_ctx_t c2m_ctx, nonterm_arg_func_t f, node_t arg) {
 #define TRY(f) try_f (c2m_ctx, f)
 #define TRY_A(f, arg) try_arg_f (c2m_ctx, f, arg)
 
+D (compound_stmt);
+
 /* Expressions: */
 D (type_name);
 D (expr);
@@ -4012,7 +4015,12 @@ D (primary_expr) {
   if (MN (T_ID, r) || MN (T_NUMBER, r) || MN (T_CH, r) || MN (T_STR, r)) {
     return r;
   } else if (M ('(')) {
-    P (expr);
+    if (C ('{')) {
+      P (compound_stmt);
+      r = new_node1 (c2m_ctx, N_STMTEXPR, r);
+    } else {
+      P (expr);
+    }
     if (M (')')) return r;
   } else if (MP (T_GENERIC, pos)) {
     PT ('(');
@@ -4993,7 +5001,6 @@ D (st_assert) {
 }
 
 /* Statements: */
-D (compound_stmt);
 
 D (label) {
   parse_ctx_t parse_ctx = c2m_ctx->parse_ctx;
@@ -8103,7 +8110,7 @@ static void classify_node (node_t n, int *expr_attr_p, int *stmt_p) {
   switch (n->code) {
     REP8 (NODE_CASE, I, L, LL, U, UL, ULL, F, D)
     REP7 (NODE_CASE, LD, CH, CH16, CH32, STR, STR16, STR32)
-    REP5 (NODE_CASE, ID, COMMA, ANDAND, OROR, EQ)
+    REP6 (NODE_CASE, ID, COMMA, ANDAND, OROR, EQ, STMTEXPR)
     REP8 (NODE_CASE, NE, LT, LE, GT, GE, ASSIGN, BITWISE_NOT, NOT)
     REP8 (NODE_CASE, AND, AND_ASSIGN, OR, OR_ASSIGN, XOR, XOR_ASSIGN, LSH, LSH_ASSIGN)
     REP8 (NODE_CASE, RSH, RSH_ASSIGN, ADD, ADD_ASSIGN, SUB, SUB_ASSIGN, MUL, MUL_ASSIGN)
@@ -9363,6 +9370,21 @@ static void check (c2m_ctx_t c2m_ctx, node_t r, node_t context) {
     }
     break;
   }
+  case N_STMTEXPR: {
+    node_t block = NL_HEAD (r->u.ops);
+    check (c2m_ctx, block, r);
+    node_t last_stmt = NL_TAIL (NL_EL (block->u.ops, 1)->u.ops);
+    if (!last_stmt || last_stmt->code != N_EXPR) {
+      error (c2m_ctx, POS (r), "last statement in statement expression is not an expression");
+      break;
+    }
+    node_t expr = NL_EL (last_stmt->u.ops, 1);
+    e1 = expr->attr;
+    t1 = e1->type;
+    e = create_expr (c2m_ctx, r);
+    *e->type = *t1;
+    break;
+  }
   case N_BLOCK:
     check_labels (c2m_ctx, NL_HEAD (r->u.ops), r);
     if (curr_scope != r)
@@ -10504,8 +10526,10 @@ static MIR_label_t get_label (c2m_ctx_t c2m_ctx, node_t target) {
   return labels->attr = MIR_new_label (c2m_ctx->ctx);
 }
 
+static op_t top_gen_last_op;
+
 static void top_gen (c2m_ctx_t c2m_ctx, node_t r, MIR_label_t true_label, MIR_label_t false_label) {
-  gen (c2m_ctx, r, true_label, false_label, FALSE, NULL);
+  top_gen_last_op = gen (c2m_ctx, r, true_label, false_label, FALSE, NULL);
 }
 
 static op_t modify_for_block_move (c2m_ctx_t c2m_ctx, op_t mem, op_t index) {
@@ -12430,6 +12454,11 @@ static op_t gen (c2m_ctx_t c2m_ctx, node_t r, MIR_label_t true_label, MIR_label_
     finish_curr_func_reg_vars (c2m_ctx);
     break;
   }
+  case N_STMTEXPR: {
+    gen (c2m_ctx, NL_HEAD (r->u.ops), NULL, NULL, FALSE, NULL);
+    res = top_gen_last_op;
+    break;
+  }
   case N_BLOCK:
     emit_label (c2m_ctx, r);
     gen (c2m_ctx, NL_EL (r->u.ops, 1), NULL, NULL, FALSE, NULL);
@@ -12839,7 +12868,7 @@ static const char *get_node_name (node_code_t code) {
     C (IGNORE);
     REP8 (C, I, L, LL, U, UL, ULL, F, D);
     REP7 (C, LD, CH, CH16, CH32, STR, STR16, STR32);
-    REP5 (C, ID, COMMA, ANDAND, OROR, EQ);
+    REP6 (C, ID, COMMA, ANDAND, OROR, EQ, STMTEXPR);
     REP8 (C, NE, LT, LE, GT, GE, ASSIGN, BITWISE_NOT, NOT);
     REP8 (C, AND, AND_ASSIGN, OR, OR_ASSIGN, XOR, XOR_ASSIGN, LSH, LSH_ASSIGN);
     REP8 (C, RSH, RSH_ASSIGN, ADD, ADD_ASSIGN, SUB, SUB_ASSIGN, MUL, MUL_ASSIGN);
@@ -13107,6 +13136,7 @@ static void print_node (c2m_ctx_t c2m_ctx, FILE *f, node_t n, int indent, int at
   case N_COMPOUND_LITERAL:
   case N_CALL:
   case N_GENERIC:
+  case N_STMTEXPR:
     if (attr_p && n->attr != NULL) print_expr (c2m_ctx, f, n->attr);
     fprintf (f, "\n");
     print_ops (c2m_ctx, f, n, indent, attr_p);


### PR DESCRIPTION
This my attempt to bring support for [statement expressions extension](https://gcc.gnu.org/onlinedocs/gcc/Statement-Exprs.html), I use this extension a lot for my C code gen, so I wish C2M could support it. Request for this feature was mentioned in issue https://github.com/vnmakarov/mir/issues/22 .

I've been able to do the following at this point:

- [x] Parsing
- [x] Checking
- [x] Generating

I am not familiar with MIR code base and this my first attempt to read and modify in its sources, so this may not have good quality and lots of things may be missing.

I was able to first implement a rudimentary parser and checker, with minor changes, it parses and checks the following with success:

```c
int main() {
    int x = ({
        int a = 0, b = 1;
        a + b;
    });
    return x;
}
```

The AST output:

```
C2MIR init end           -- 266 usec
    preprocessor tokens -- 52, parse tokens -- 31
  C2MIR preprocessor end    -- 355 usec
  C2MIR parser end          -- 408 usec
    77: MODULE (test.c:1): the top scope, size = 0, offset = 0
    20:   LIST (test.c:1)
    76:     FUNC_DEF (test.c:1): scope node = 77,  extern linkage, func int (params node 39), raw size = 8, align = 8 , offset = 0
    33:       LIST (test.c:1): int 
    34:         INT (test.c:1)
    36:       DECL (test.c:1)
     8:         ID (test.c:1) main
    35:         LIST (test.c:1)
    40:           FUNC (test.c:1)
    39:             LIST ()
    41:       LIST ()
    44:       BLOCK (test.c:1): higher scope node 77, size = 0, offset = 0
    43:         LIST ()
    42:         LIST (test.c:2)
    72:           SPEC_DECL (test.c:2): scope node = 44, int, raw size = 4, align = 4 , used, reg
    71:             SHARE (test.c:2)
    45:               LIST (test.c:2): int, raw size = 4, align = 4 
    46:                 INT (test.c:2)
    49:             DECL (test.c:2)
    10:               ID (test.c:2) x
    48:               LIST ()
    70:             STMTEXPR (test.c:2): int 
    53:               BLOCK (test.c:2): higher scope node 44, size = 0, offset = 0
    52:                 LIST ()
    51:                 LIST (test.c:3)
    60:                   SPEC_DECL (test.c:3): scope node = 53, int, raw size = 4, align = 4 , used, reg
    59:                     SHARE (test.c:3)
    54:                       LIST (test.c:3): int, raw size = 4, align = 4 
    55:                         INT (test.c:3)
    58:                     DECL (test.c:3)
    12:                       ID (test.c:3) a
    57:                       LIST ()
    13:                     I (test.c:3) 0: int, raw size = 4, align = 4 , const = 0
    64:                   SPEC_DECL (test.c:3): scope node = 53, int, raw size = 4, align = 4 , used, reg
    63:                     SHARE (test.c:3)
    54:                       LIST (test.c:3): int, raw size = 4, align = 4 
    55:                         INT (test.c:3)
    62:                     DECL (test.c:3)
    14:                       ID (test.c:3) b
    61:                       LIST ()
    15:                     I (test.c:3) 1: int, raw size = 4, align = 4 , const = 1
    69:                   EXPR (test.c:4)
    66:                     LIST ()
    68:                     ADD (test.c:4): int, raw size = 4, align = 4 
    16:                       ID (test.c:4) a: lvalue, int, raw size = 4, align = 4 
    17:                       ID (test.c:4) b: lvalue, int, raw size = 4, align = 4 
    75:           RETURN (test.c:6)
    74:             LIST ()
    19:             ID (test.c:6) x: lvalue, int, raw size = 4, align = 4 
```

@vnmakarov Is this PR is a dead end or do you think code generation is doable without touching much other generator parts?
