### PR TITLE
don't destroy llvm module in llvm2mir function

### DIFF
--- a/llvm2mir/llvm2mir-driver.c
+++ b/llvm2mir/llvm2mir-driver.c
@@ -133,6 +133,7 @@ int main (int argc, char *argv[], char *env[]) {
   LLVMDisposeMemoryBuffer (memory_buffer);
   context = MIR_init ();
   mir_module = llvm2mir (context, module);
+  LLVMDisposeModule (module);
   if (!gen_p && !interpr_p) MIR_output (context, stderr);
   main_func = NULL;
   for (f = DLIST_HEAD (MIR_item_t, mir_module->items); f != NULL; f = DLIST_NEXT (MIR_item_t, f))

--- a/llvm2mir/llvm2mir.c
+++ b/llvm2mir/llvm2mir.c
@@ -1768,7 +1768,6 @@ MIR_module_t llvm2mir (MIR_context_t c, LLVMModuleRef module) {
   }
 
   MIR_finish_module (context);
-  LLVMDisposeModule (module);
   finish_bb_gen_info ();
   HTAB_DESTROY (expr_res_t, expr_res_tab);
   HTAB_DESTROY (item_t, item_tab);


### PR DESCRIPTION
The llvm module is passed by the caller, `llvm2mir` function does not own this
module, so it shouldn't destroy it.