### PR TITLE
add MIR_get_item_func function

### DIFF
--- a/mir.c
+++ b/mir.c
@@ -521,6 +521,15 @@ const char *MIR_item_name (MIR_context_t ctx, MIR_item_t item) {
   }
 }
 
+MIR_func_t MIR_get_item_func (MIR_context_t ctx, MIR_item_t item) {
+  mir_assert (item != NULL);
+  if (item->item_type == MIR_func_item) {
+    return item->u.func;
+  } else {
+    return NULL;
+  }
+}
+
 #if !MIR_NO_IO
 static void io_init (MIR_context_t ctx);
 static void io_finish (MIR_context_t ctx);

--- a/mir.h
+++ b/mir.h
@@ -508,6 +508,7 @@ extern MIR_item_t MIR_new_vararg_func_arr (MIR_context_t ctx, const char *name, 
 extern MIR_item_t MIR_new_vararg_func (MIR_context_t ctx, const char *name, size_t nres,
                                        MIR_type_t *res_types, size_t nargs, ...);
 extern const char *MIR_item_name (MIR_context_t ctx, MIR_item_t item);
+extern MIR_func_t MIR_get_item_func(MIR_context_t ctx, MIR_item_t item);
 extern MIR_reg_t MIR_new_func_reg (MIR_context_t ctx, MIR_func_t func, MIR_type_t type,
                                    const char *name);
 extern void MIR_finish_func (MIR_context_t ctx);


### PR DESCRIPTION
get MIR_func_t  from  MIR_item_t with function. 
sometimes we can not use item->u.func, when wrap MIR for other language.