### PR TITLE
Fix Windows testing in AMD64-Linux-OSX-Windows-test.yml

### DIFF
--- a/.github/workflows/AMD64-Linux-OSX-Windows-test.yml
+++ b/.github/workflows/AMD64-Linux-OSX-Windows-test.yml
@@ -19,6 +19,7 @@ jobs:
     - name: cmake test
       if: runner.os == 'Windows'
       run: |
-        cmake -G 'Visual Studio 16 2019' -A x64 -DBUILD_TESTING=ON
+        cmake -A x64 -DBUILD_TESTING=ON
         cmake --build . --config Release
         ctest --verbose --output-on-failure
+


### PR DESCRIPTION
No need to specify the generator, this is currently causing the build to fail under Windows.