### PR TITLE
Changes to build with -m32/wasm

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -204,7 +204,7 @@ $(BUILD_DIR)/$(SOLIB): $(BUILD_DIR)/mir.$(OBJSUFF) $(BUILD_DIR)/mir-gen.$(OBJSUF
 ifeq ($(CC),cl)
 	$(CC) -nologo -D_USRDLL -D_WINDLL $^ -link -DLL -OUT:$@
 else
-	$(CC) $(SOLIBFLAGS) -o $@ $^
+	$(CC) $(LDFLAGS) $(SOLIBFLAGS) -o $@ $^
 endif
 
 # ------------------ C2M --------------------------

--- a/c2mir/c2mir-driver.c
+++ b/c2mir/c2mir-driver.c
@@ -632,7 +632,11 @@ static void sort_modules (MIR_context_t ctx) {
   VARR_DESTROY (MIR_module_t, modules);
 }
 
-int main (int argc, char *argv[], char *env[]) {
+int main (int argc, char *argv[]
+#ifndef __wasm__
+    , char *env[]
+#endif
+) {
   int i, bin_p;
   size_t len;
 
@@ -774,7 +778,11 @@ int main (int argc, char *argv[], char *env[]) {
     MIR_val_t val;
     MIR_module_t module;
     MIR_item_t func, main_func = NULL;
-    uint64_t (*fun_addr) (int, void *argv, char *env[]);
+    uint64_t (*fun_addr) (int, void *argv
+#ifndef __wasm__
+            , char *env[]
+#endif
+            );
     double start_time;
 
 #if MIR_PARALLEL_GEN
@@ -821,7 +829,12 @@ int main (int argc, char *argv[], char *env[]) {
         MIR_interp (main_ctx, main_func, &val, 3,
                     (MIR_val_t){.i = VARR_LENGTH (char_ptr_t, exec_argv)},
                     (MIR_val_t){.a = (void *) VARR_ADDR (char_ptr_t, exec_argv)},
-                    (MIR_val_t){.a = (void *) env});
+#ifndef __wasm__
+                    (MIR_val_t){.a = (void *) env}
+#else
+                    NULL
+#endif
+                    );
         result_code = val.i;
         if (options.verbose_p) {
           fprintf (stderr, "  execution       -- %.0f msec\n",
@@ -847,7 +860,11 @@ int main (int argc, char *argv[], char *env[]) {
         fun_addr = gen_exec_p && n_gen > 1 ? MIR_gen (main_ctx, 0, main_func) : main_func->addr;
         start_time = real_usec_time ();
         result_code
-          = fun_addr (VARR_LENGTH (char_ptr_t, exec_argv), VARR_ADDR (char_ptr_t, exec_argv), env);
+          = fun_addr (VARR_LENGTH (char_ptr_t, exec_argv), VARR_ADDR (char_ptr_t, exec_argv)
+#ifndef __wasm__
+                    ,env
+#endif
+                );
         if (options.verbose_p) {
           fprintf (stderr, "  execution       -- %.0f msec\n",
                    (real_usec_time () - start_time) / 1000.0);

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -26,7 +26,9 @@
 
 #include "c2mir.h"
 
-#if defined(__x86_64__) || defined(_M_AMD64)
+#if defined(__i686__) || defined(__wasm32__)
+#include "x86_64/cx86_64.h"
+#elif defined(__x86_64__) || defined(_M_AMD64)
 #include "x86_64/cx86_64.h"
 #elif defined(__aarch64__)
 #include "aarch64/caarch64.h"
@@ -331,7 +333,9 @@ typedef struct {
   const char *name, *content;
 } string_include_t;
 
-#if defined(__x86_64__) || defined(_M_AMD64)
+#if defined(__i686__) || defined(__wasm32__)
+#include "x86_64/cx86_64-code.c"
+#elif defined(__x86_64__) || defined(_M_AMD64)
 #include "x86_64/cx86_64-code.c"
 #elif defined(__aarch64__)
 #include "aarch64/caarch64-code.c"
@@ -3893,8 +3897,8 @@ static int tpname_eq (tpname_t tpname1, tpname_t tpname2, void *arg) {
 
 static htab_hash_t tpname_hash (tpname_t tpname, void *arg) {
   return (mir_hash_finish (
-    mir_hash_step (mir_hash_step (mir_hash_init (0x42), (uint64_t) tpname.id->u.s.s),
-                   (uint64_t) tpname.scope)));
+    mir_hash_step (mir_hash_step (mir_hash_init (0x42), (uintptr_t) tpname.id->u.s.s),
+                   (uintptr_t) tpname.scope)));
 }
 
 static void tpname_init (c2m_ctx_t c2m_ctx) {
@@ -5465,9 +5469,9 @@ static int symbol_eq (symbol_t s1, symbol_t s2, void *arg) {
 
 static htab_hash_t symbol_hash (symbol_t s, void *arg) {
   return (mir_hash_finish (
-    mir_hash_step (mir_hash_step (mir_hash_step (mir_hash_init (0x42), (uint64_t) s.mode),
-                                  (uint64_t) s.id->u.s.s),
-                   (uint64_t) s.scope)));
+    mir_hash_step (mir_hash_step (mir_hash_step (mir_hash_init (0x42), (uintptr_t) s.mode),
+                                  (uintptr_t) s.id->u.s.s),
+                   (uintptr_t) s.scope)));
 }
 
 static void symbol_clear (symbol_t sym, void *arg) { VARR_DESTROY (node_t, sym.defs); }

--- a/c2mir/x86_64/mirc_x86_64_linux.h
+++ b/c2mir/x86_64/mirc_x86_64_linux.h
@@ -98,7 +98,7 @@ static char x86_64_mirc[]
     "typedef unsigned short char16_t;\n"
     "typedef unsigned int char32_t;\n"
     "\n"
-#if defined(__linux__)
+#if defined(__linux__) || defined(__wasm__)
     "#define __gnu_linux__ 1\n"
     "#define __linux 1\n"
     "#define __linux__ 1\n"

--- a/llvm2mir/llvm2mir.c
+++ b/llvm2mir/llvm2mir.c
@@ -69,7 +69,7 @@ static int bb_gen_info_eq (bb_gen_info_t bb_gen_info1, bb_gen_info_t bb_gen_info
   return bb_gen_info1->bb == bb_gen_info2->bb;
 }
 static htab_hash_t bb_gen_info_hash (bb_gen_info_t bb_gen_info, void *arg) {
-  return mir_hash_finish (mir_hash_step (mir_hash_init (0x42), (uint64_t) bb_gen_info->bb));
+  return mir_hash_finish (mir_hash_step (mir_hash_init (0x42), (uintptr_t) bb_gen_info->bb));
 }
 
 static void init_bb_gen_info (void) {
@@ -223,7 +223,7 @@ static int expr_res_eq (expr_res_t expr_res1, expr_res_t expr_res2, void *arg) {
   return expr_res1.expr == expr_res2.expr;
 }
 static htab_hash_t expr_res_hash (expr_res_t expr_res, void *arg) {
-  return mir_hash_finish (mir_hash_step (mir_hash_init (0x42), (uint64_t) expr_res.expr));
+  return mir_hash_finish (mir_hash_step (mir_hash_init (0x42), (uintptr_t) expr_res.expr));
 }
 
 static void add_mir_reg_to_table (LLVMValueRef expr, MIR_reg_t reg) {

--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -2112,7 +2112,7 @@ static void out_insn (gen_ctx_t gen_ctx, MIR_insn_t insn, const char *replacemen
     int prefix = -1, disp8 = -1, imm8 = -1, lb = -1;
     int64_t disp32 = -1, imm32 = -1;
     int imm64_p = FALSE;
-    uint64_t imm64 = 0, v;
+    uintptr_t imm64 = 0, v;
     MIR_op_t op;
     int const_ref_num = -1, label_ref_num = -1, switch_table_addr_p = FALSE;
 
@@ -2261,9 +2261,9 @@ static void out_insn (gen_ctx_t gen_ctx, MIR_insn_t insn, const char *replacemen
         imm64_p = TRUE;
         if (op.u.ref->item_type == MIR_data_item && op.u.ref->u.data->name != NULL
             && _MIR_reserved_ref_name_p (ctx, op.u.ref->u.data->name))
-          imm64 = (uint64_t) op.u.ref->u.data->u.els;
+          imm64 = (uintptr_t) op.u.ref->u.data->u.els;
         else
-          imm64 = (uint64_t) op.u.ref->addr;
+          imm64 = (uintptr_t) op.u.ref->addr;
         break;
       case 'T': {
         gen_assert (!switch_table_addr_p && switch_table_addr_start < 0);

--- a/mir-hash.h
+++ b/mir-hash.h
@@ -57,7 +57,7 @@ static inline uint64_t mir_mum (uint64_t v, uint64_t c, int relax_p) {
   return v1 * c1 + (rm >> 32) + v2 * c2 + (rm << 32);
 }
 
-static inline uint64_t mir_round (uint64_t state, uint64_t v, int relax_p) {
+static inline uint64_t mir_round (uint64_t state, uintptr_t v, int relax_p) {
   state ^= mir_mum (v, p1, relax_p);
   return state ^ mir_mum (state, p2, relax_p);
 }
@@ -88,7 +88,7 @@ static inline uint64_t mir_hash_strict (const void *key, size_t len, uint64_t se
 }
 
 static inline uint64_t mir_hash_init (uint64_t seed) { return seed; }
-static inline uint64_t mir_hash_step (uint64_t h, uint64_t key) { return mir_round (h, key, 1); }
+static inline uint64_t mir_hash_step (uint64_t h, uintptr_t key) { return mir_round (h, key, 1); }
 static inline uint64_t mir_hash_finish (uint64_t h) { return mir_round (h, h, 1); }
 
 static inline uint64_t mir_hash64 (uint64_t key, uint64_t seed) {

--- a/mir-interp.c
+++ b/mir-interp.c
@@ -473,41 +473,41 @@ static ALWAYS_INLINE double get_d (MIR_val_t *v) { return v->d; }
 static ALWAYS_INLINE long double get_ld (MIR_val_t *v) { return v->ld; }
 
 static ALWAYS_INLINE void **get_aop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].a; }
-static ALWAYS_INLINE int64_t *get_iop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].i; }
-static ALWAYS_INLINE uint64_t *get_uop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].u; }
+static ALWAYS_INLINE intptr_t *get_iop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].i; }
+static ALWAYS_INLINE uintptr_t *get_uop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].u; }
 static ALWAYS_INLINE float *get_fop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].f; }
 static ALWAYS_INLINE double *get_dop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].d; }
 static ALWAYS_INLINE long double *get_ldop (MIR_val_t *bp, code_t c) { return &bp[get_i (c)].ld; }
 
-static ALWAYS_INLINE int64_t *get_2iops (MIR_val_t *bp, code_t c, int64_t *p) {
+static ALWAYS_INLINE intptr_t *get_2iops (MIR_val_t *bp, code_t c, intptr_t *p) {
   *p = *get_iop (bp, c + 1);
   return get_iop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_2isops (MIR_val_t *bp, code_t c, int32_t *p) {
+static ALWAYS_INLINE intptr_t *get_2isops (MIR_val_t *bp, code_t c, int32_t *p) {
   *p = *get_iop (bp, c + 1);
   return get_iop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_3iops (MIR_val_t *bp, code_t c, int64_t *p1, int64_t *p2) {
+static ALWAYS_INLINE intptr_t *get_3iops (MIR_val_t *bp, code_t c, intptr_t *p1, intptr_t *p2) {
   *p1 = *get_iop (bp, c + 1);
   *p2 = *get_iop (bp, c + 2);
   return get_iop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_3isops (MIR_val_t *bp, code_t c, int32_t *p1, int32_t *p2) {
+static ALWAYS_INLINE intptr_t *get_3isops (MIR_val_t *bp, code_t c, int32_t *p1, int32_t *p2) {
   *p1 = *get_iop (bp, c + 1);
   *p2 = *get_iop (bp, c + 2);
   return get_iop (bp, c);
 }
 
-static ALWAYS_INLINE uint64_t *get_3uops (MIR_val_t *bp, code_t c, uint64_t *p1, uint64_t *p2) {
+static ALWAYS_INLINE uintptr_t *get_3uops (MIR_val_t *bp, code_t c, uintptr_t *p1, uintptr_t *p2) {
   *p1 = *get_uop (bp, c + 1);
   *p2 = *get_uop (bp, c + 2);
   return get_uop (bp, c);
 }
 
-static ALWAYS_INLINE uint64_t *get_3usops (MIR_val_t *bp, code_t c, uint32_t *p1, uint32_t *p2) {
+static ALWAYS_INLINE uintptr_t *get_3usops (MIR_val_t *bp, code_t c, uint32_t *p1, uint32_t *p2) {
   *p1 = *get_uop (bp, c + 1);
   *p2 = *get_uop (bp, c + 2);
   return get_uop (bp, c);
@@ -524,7 +524,7 @@ static ALWAYS_INLINE float *get_3fops (MIR_val_t *bp, code_t c, float *p1, float
   return get_fop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_fcmp_ops (MIR_val_t *bp, code_t c, float *p1, float *p2) {
+static ALWAYS_INLINE intptr_t *get_fcmp_ops (MIR_val_t *bp, code_t c, float *p1, float *p2) {
   *p1 = *get_fop (bp, c + 1);
   *p2 = *get_fop (bp, c + 2);
   return get_iop (bp, c);
@@ -541,7 +541,7 @@ static ALWAYS_INLINE double *get_3dops (MIR_val_t *bp, code_t c, double *p1, dou
   return get_dop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_dcmp_ops (MIR_val_t *bp, code_t c, double *p1, double *p2) {
+static ALWAYS_INLINE intptr_t *get_dcmp_ops (MIR_val_t *bp, code_t c, double *p1, double *p2) {
   *p1 = *get_dop (bp, c + 1);
   *p2 = *get_dop (bp, c + 2);
   return get_iop (bp, c);
@@ -559,63 +559,63 @@ static ALWAYS_INLINE long double *get_3ldops (MIR_val_t *bp, code_t c, long doub
   return get_ldop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t *get_ldcmp_ops (MIR_val_t *bp, code_t c, long double *p1,
+static ALWAYS_INLINE intptr_t *get_ldcmp_ops (MIR_val_t *bp, code_t c, long double *p1,
                                              long double *p2) {
   *p1 = *get_ldop (bp, c + 1);
   *p2 = *get_ldop (bp, c + 2);
   return get_iop (bp, c);
 }
 
-static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[get_i (c)].i; }
+static ALWAYS_INLINE intptr_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[get_i (c)].i; }
 
 #define EXT(tp)                     \
   do {                              \
-    int64_t *r = get_iop (bp, ops); \
+    intptr_t *r = get_iop (bp, ops); \
     tp s = *get_iop (bp, ops + 1);  \
     *r = s;                         \
   } while (0)
 #define IOP2(op)                 \
   do {                           \
-    int64_t *r, p;               \
+    intptr_t *r, p;               \
     r = get_2iops (bp, ops, &p); \
     *r = op p;                   \
   } while (0)
 #define IOP2S(op)                 \
   do {                            \
-    int64_t *r;                   \
+    intptr_t *r;                   \
     int32_t p;                    \
     r = get_2isops (bp, ops, &p); \
     *r = op p;                    \
   } while (0)
 #define IOP3(op)                       \
   do {                                 \
-    int64_t *r, p1, p2;                \
+    intptr_t *r, p1, p2;                \
     r = get_3iops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                     \
   } while (0)
 #define IOP3S(op)                       \
   do {                                  \
-    int64_t *r;                         \
+    intptr_t *r;                         \
     int32_t p1, p2;                     \
     r = get_3isops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                      \
   } while (0)
 #define ICMP(op)                       \
   do {                                 \
-    int64_t *r, p1, p2;                \
+    intptr_t *r, p1, p2;                \
     r = get_3iops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                     \
   } while (0)
 #define ICMPS(op)                       \
   do {                                  \
-    int64_t *r;                         \
+    intptr_t *r;                         \
     int32_t p1, p2;                     \
     r = get_3isops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                      \
   } while (0)
 #define BICMP(op)                                                       \
   do {                                                                  \
-    int64_t op1 = *get_iop (bp, ops + 1), op2 = *get_iop (bp, ops + 2); \
+    intptr_t op1 = *get_iop (bp, ops + 1), op2 = *get_iop (bp, ops + 2); \
     if (op1 op op2) pc = code + get_i (ops);                            \
   } while (0)
 #define BICMPS(op)                                                      \
@@ -625,46 +625,46 @@ static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[
   } while (0)
 #define UOP3(op)                       \
   do {                                 \
-    uint64_t *r, p1, p2;               \
+    uintptr_t *r, p1, p2;               \
     r = get_3uops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                     \
   } while (0)
 #define UOP3S(op)                       \
   do {                                  \
-    uint64_t *r;                        \
+    uintptr_t *r;                        \
     uint32_t p1, p2;                    \
     r = get_3usops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                      \
   } while (0)
 #define UIOP3(op)                      \
   do {                                 \
-    uint64_t *r, p1, p2;               \
+    uintptr_t *r, p1, p2;               \
     r = get_3uops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                     \
   } while (0)
 #define UIOP3S(op)                      \
   do {                                  \
-    uint64_t *r;                        \
+    uintptr_t *r;                        \
     uint32_t p1, p2;                    \
     r = get_3usops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                      \
   } while (0)
 #define UCMP(op)                       \
   do {                                 \
-    uint64_t *r, p1, p2;               \
+    uintptr_t *r, p1, p2;               \
     r = get_3uops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                     \
   } while (0)
 #define UCMPS(op)                       \
   do {                                  \
-    uint64_t *r;                        \
+    uintptr_t *r;                        \
     uint32_t p1, p2;                    \
     r = get_3usops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                      \
   } while (0)
 #define BUCMP(op)                                                        \
   do {                                                                   \
-    uint64_t op1 = *get_uop (bp, ops + 1), op2 = *get_uop (bp, ops + 2); \
+    uintptr_t op1 = *get_uop (bp, ops + 1), op2 = *get_uop (bp, ops + 2); \
     if (op1 op op2) pc = code + get_i (ops);                             \
   } while (0)
 #define BUCMPS(op)                                                       \
@@ -687,7 +687,7 @@ static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[
   } while (0)
 #define FCMP(op)                          \
   do {                                    \
-    int64_t *r;                           \
+    intptr_t *r;                           \
     float p1, p2;                         \
     r = get_fcmp_ops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                        \
@@ -712,7 +712,7 @@ static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[
   } while (0)
 #define DCMP(op)                          \
   do {                                    \
-    int64_t *r;                           \
+    intptr_t *r;                           \
     double p1, p2;                        \
     r = get_dcmp_ops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                        \
@@ -737,7 +737,7 @@ static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[
   } while (0)
 #define LDCMP(op)                          \
   do {                                     \
-    int64_t *r;                            \
+    intptr_t *r;                            \
     long double p1, p2;                    \
     r = get_ldcmp_ops (bp, ops, &p1, &p2); \
     *r = p1 op p2;                         \
@@ -751,13 +751,13 @@ static ALWAYS_INLINE int64_t get_mem_addr (MIR_val_t *bp, code_t c) { return bp[
 #define LD(op, val_type, mem_type)          \
   do {                                      \
     val_type *r = get_##op (bp, ops);       \
-    int64_t a = get_mem_addr (bp, ops + 1); \
+    intptr_t a = get_mem_addr (bp, ops + 1); \
     *r = *((mem_type *) a);                 \
   } while (0)
 #define ST(op, val_type, mem_type)          \
   do {                                      \
     val_type v = *get_##op (bp, ops);       \
-    int64_t a = get_mem_addr (bp, ops + 1); \
+    intptr_t a = get_mem_addr (bp, ops + 1); \
     *((mem_type *) a) = v;                  \
   } while (0)
 
@@ -972,7 +972,7 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
 #endif
 
   CASE (MIR_MOV, 2) {
-    int64_t p, *r = get_2iops (bp, ops, &p);
+    intptr_t p, *r = get_2iops (bp, ops, &p);
     *r = p;
     END_INSN;
   }
@@ -999,21 +999,21 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
   SCASE (MIR_UEXT32, 2, EXT (uint32_t));
   CASE (MIR_I2F, 2) {
     float *r = get_fop (bp, ops);
-    int64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
   }
   CASE (MIR_I2D, 2) {
     double *r = get_dop (bp, ops);
-    int64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
   }
   CASE (MIR_I2LD, 2) {
     long double *r = get_ldop (bp, ops);
-    int64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
@@ -1021,42 +1021,42 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
 
   CASE (MIR_UI2F, 2) {
     float *r = get_fop (bp, ops);
-    uint64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
   }
   CASE (MIR_UI2D, 2) {
     double *r = get_dop (bp, ops);
-    uint64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
   }
   CASE (MIR_UI2LD, 2) {
     long double *r = get_ldop (bp, ops);
-    uint64_t i = *get_iop (bp, ops + 1);
+    intptr_t i = *get_iop (bp, ops + 1);
 
     *r = i;
     END_INSN;
   }
 
   CASE (MIR_F2I, 2) {
-    int64_t *r = get_iop (bp, ops);
+    intptr_t *r = get_iop (bp, ops);
     float f = *get_fop (bp, ops + 1);
 
     *r = f;
     END_INSN;
   }
   CASE (MIR_D2I, 2) {
-    int64_t *r = get_iop (bp, ops);
+    intptr_t *r = get_iop (bp, ops);
     double d = *get_dop (bp, ops + 1);
 
     *r = d;
     END_INSN;
   }
   CASE (MIR_LD2I, 2) {
-    int64_t *r = get_iop (bp, ops);
+    intptr_t *r = get_iop (bp, ops);
     long double ld = *get_ldop (bp, ops + 1);
 
     *r = ld;
@@ -1325,10 +1325,10 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
   }
 
   CASE (MIR_ALLOCA, 2) {
-    int64_t *r, s;
+    intptr_t *r, s;
 
     r = get_2iops (bp, ops, &s);
-    *r = (uint64_t) alloca (s);
+    *r = (intptr_t) alloca (s);
     END_INSN;
   }
   CASE (MIR_BSTART, 1) {
@@ -1339,15 +1339,15 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
   }
   SCASE (MIR_BEND, 1, bend_builtin (*get_aop (bp, ops)));
   CASE (MIR_VA_ARG, 3) {
-    int64_t *r, va, tp;
+    intptr_t *r, va, tp;
 
     r = get_2iops (bp, ops, &va);
     tp = get_i (ops + 2);
-    *r = (uint64_t) va_arg_builtin ((void *) va, tp);
+    *r = (intptr_t) va_arg_builtin ((void *) va, tp);
     END_INSN;
   }
   CASE (MIR_VA_BLOCK_ARG, 4) {
-    int64_t *r, va, size;
+    intptr_t *r, va, size;
 
     r = get_3iops (bp, ops, &va, &size);
     va_block_arg_builtin ((void *) *r, (void *) va, size, *get_iop (bp, ops + 3));
@@ -1356,13 +1356,13 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
   SCASE (MIR_VA_START, 1, va_start_interp_builtin (ctx, bp[get_i (ops)].a, bp[-1].a));
   SCASE (MIR_VA_END, 1, va_end_interp_builtin (ctx, bp[get_i (ops)].a));
 
-  SCASE (IC_LDI8, 2, LD (iop, int64_t, int8_t));
-  SCASE (IC_LDU8, 2, LD (uop, uint64_t, uint8_t));
-  SCASE (IC_LDI16, 2, LD (iop, int64_t, int16_t));
-  SCASE (IC_LDU16, 2, LD (uop, uint64_t, uint16_t));
-  SCASE (IC_LDI32, 2, LD (iop, int64_t, int32_t));
-  SCASE (IC_LDU32, 2, LD (uop, uint64_t, uint32_t));
-  SCASE (IC_LDI64, 2, LD (iop, int64_t, int64_t));
+  SCASE (IC_LDI8, 2, LD (iop, intptr_t, int8_t));
+  SCASE (IC_LDU8, 2, LD (uop, uintptr_t, uint8_t));
+  SCASE (IC_LDI16, 2, LD (iop, intptr_t, int16_t));
+  SCASE (IC_LDU16, 2, LD (uop, uintptr_t, uint16_t));
+  SCASE (IC_LDI32, 2, LD (iop, intptr_t, int32_t));
+  SCASE (IC_LDU32, 2, LD (uop, uintptr_t, uint32_t));
+  SCASE (IC_LDI64, 2, LD (iop, intptr_t, int64_t));
   SCASE (IC_LDF, 2, LD (fop, float, float));
   SCASE (IC_LDD, 2, LD (dop, double, double));
   SCASE (IC_LDLD, 2, LD (ldop, long double, long double));
@@ -1382,7 +1382,7 @@ static void OPTIMIZE eval (MIR_context_t ctx, func_desc_t func_desc, MIR_val_t *
   SCASE (IC_STD, 2, ST (dop, double, double));
   SCASE (IC_STLD, 2, ST (ldop, long double, long double));
   CASE (IC_MOVI, 2) {
-    int64_t *r = get_iop (bp, ops), imm = get_i (ops + 1);
+    intptr_t *r = get_iop (bp, ops), imm = get_i (ops + 1);
     *r = imm;
     END_INSN;
   }
@@ -1543,10 +1543,10 @@ static void call (MIR_context_t ctx, MIR_val_t *bp, MIR_op_t *insn_arg_ops, code
     case MIR_T_F: call_res_args[i + nres].f = arg_vals[i].f; break;
     case MIR_T_D: call_res_args[i + nres].d = arg_vals[i].d; break;
     case MIR_T_LD: call_res_args[i + nres].ld = arg_vals[i].ld; break;
-    case MIR_T_P: call_res_args[i + nres].u = (uint64_t) arg_vals[i].a; break;
+    case MIR_T_P: call_res_args[i + nres].u = (uintptr_t) arg_vals[i].a; break;
     default:
       mir_assert (MIR_all_blk_type_p (type));
-      call_res_args[i + nres].u = (uint64_t) arg_vals[i].a;
+      call_res_args[i + nres].u = (uintptr_t) arg_vals[i].a;
       break;
     }
   }

--- a/mir.c
+++ b/mir.c
@@ -551,8 +551,8 @@ void MIR_set_error_func (MIR_context_t ctx, MIR_error_func_t func) {  // ?? atom
 
 static htab_hash_t item_hash (MIR_item_t it, void *arg) {
   return mir_hash_finish (
-    mir_hash_step (mir_hash_step (mir_hash_init (28), (uint64_t) MIR_item_name (NULL, it)),
-                   (uint64_t) it->module));
+    mir_hash_step (mir_hash_step (mir_hash_init (28), (uintptr_t) MIR_item_name (NULL, it)),
+                   (uintptr_t) it->module));
 }
 static int item_eq (MIR_item_t it1, MIR_item_t it2, void *arg) {
   return it1->module == it2->module && MIR_item_name (NULL, it1) == MIR_item_name (NULL, it2);
@@ -2212,12 +2212,12 @@ int MIR_op_eq_p (MIR_context_t ctx, MIR_op_t op1, MIR_op_t op2) {
 }
 
 htab_hash_t MIR_op_hash_step (MIR_context_t ctx, htab_hash_t h, MIR_op_t op) {
-  h = mir_hash_step (h, (uint64_t) op.mode);
+  h = mir_hash_step (h, (uintptr_t) op.mode);
   switch (op.mode) {
-  case MIR_OP_REG: return mir_hash_step (h, (uint64_t) op.u.reg);
-  case MIR_OP_HARD_REG: return mir_hash_step (h, (uint64_t) op.u.hard_reg);
-  case MIR_OP_INT: return mir_hash_step (h, (uint64_t) op.u.i);
-  case MIR_OP_UINT: return mir_hash_step (h, (uint64_t) op.u.u);
+  case MIR_OP_REG: return mir_hash_step (h, (uintptr_t) op.u.reg);
+  case MIR_OP_HARD_REG: return mir_hash_step (h, (uintptr_t) op.u.hard_reg);
+  case MIR_OP_INT: return mir_hash_step (h, (uintptr_t) op.u.i);
+  case MIR_OP_UINT: return mir_hash_step (h, (uintptr_t) op.u.u);
   case MIR_OP_FLOAT: {
     union {
       double d;
@@ -2239,25 +2239,25 @@ htab_hash_t MIR_op_hash_step (MIR_context_t ctx, htab_hash_t h, MIR_op_t op) {
   }
   case MIR_OP_REF:
     if (op.u.ref->item_type == MIR_export_item || op.u.ref->item_type == MIR_import_item)
-      return mir_hash_step (h, (uint64_t) MIR_item_name (ctx, op.u.ref));
-    return mir_hash_step (h, (uint64_t) op.u.ref);
-  case MIR_OP_STR: return mir_hash_step (h, (uint64_t) op.u.str.s);
+      return mir_hash_step (h, (uintptr_t) MIR_item_name (ctx, op.u.ref));
+    return mir_hash_step (h, (uintptr_t) op.u.ref);
+  case MIR_OP_STR: return mir_hash_step (h, (uintptr_t) op.u.str.s);
   case MIR_OP_MEM:
-    h = mir_hash_step (h, (uint64_t) op.u.mem.type);
-    h = mir_hash_step (h, (uint64_t) op.u.mem.disp);
-    h = mir_hash_step (h, (uint64_t) op.u.mem.base);
-    h = mir_hash_step (h, (uint64_t) op.u.mem.index);
-    if (op.u.mem.index != 0) h = mir_hash_step (h, (uint64_t) op.u.mem.scale);
+    h = mir_hash_step (h, (uintptr_t) op.u.mem.type);
+    h = mir_hash_step (h, (uintptr_t) op.u.mem.disp);
+    h = mir_hash_step (h, (uintptr_t) op.u.mem.base);
+    h = mir_hash_step (h, (uintptr_t) op.u.mem.index);
+    if (op.u.mem.index != 0) h = mir_hash_step (h, (uintptr_t) op.u.mem.scale);
     break;
   case MIR_OP_HARD_REG_MEM:
-    h = mir_hash_step (h, (uint64_t) op.u.hard_reg_mem.type);
-    h = mir_hash_step (h, (uint64_t) op.u.hard_reg_mem.disp);
-    h = mir_hash_step (h, (uint64_t) op.u.hard_reg_mem.base);
-    h = mir_hash_step (h, (uint64_t) op.u.hard_reg_mem.index);
+    h = mir_hash_step (h, (uintptr_t) op.u.hard_reg_mem.type);
+    h = mir_hash_step (h, (uintptr_t) op.u.hard_reg_mem.disp);
+    h = mir_hash_step (h, (uintptr_t) op.u.hard_reg_mem.base);
+    h = mir_hash_step (h, (uintptr_t) op.u.hard_reg_mem.index);
     if (op.u.hard_reg_mem.index != MIR_NON_HARD_REG)
       h = mir_hash_step (h, (uint64_t) op.u.hard_reg_mem.scale);
     break;
-  case MIR_OP_LABEL: return mir_hash_step (h, (uint64_t) op.u.label);
+  case MIR_OP_LABEL: return mir_hash_step (h, (uintptr_t) op.u.label);
   default: mir_assert (FALSE); /* we should not have other operands here */
   }
   return h;
@@ -2734,8 +2734,8 @@ static htab_hash_t val_hash (val_t v, void *arg) {
   MIR_context_t ctx = arg;
   htab_hash_t h;
 
-  h = mir_hash_step (mir_hash_init (0), (uint64_t) v.code);
-  h = mir_hash_step (h, (uint64_t) v.type);
+  h = mir_hash_step (mir_hash_init (0), (uintptr_t) v.code);
+  h = mir_hash_step (h, (uintptr_t) v.type);
   h = MIR_op_hash_step (ctx, h, v.op1);
   if (v.code != MIR_INSN_BOUND) h = MIR_op_hash_step (ctx, h, v.op2);
   return mir_hash_finish (h);
@@ -3816,7 +3816,7 @@ static code_holder_t *get_last_code_holder (MIR_context_t ctx, size_t size) {
 
   if ((len = VARR_LENGTH (code_holder_t, code_holders)) > 0) {
     ch_ptr = VARR_ADDR (code_holder_t, code_holders) + len - 1;
-    ch_ptr->free = (uint8_t *) ((uint64_t) (ch_ptr->free + 15) / 16 * 16); /* align */
+    ch_ptr->free = (uint8_t *) ((uintptr_t) (ch_ptr->free + 15) / 16 * 16); /* align */
     if (ch_ptr->free + size <= ch_ptr->bound) return ch_ptr;
   }
   npages = (size + page_size) / page_size;
@@ -3832,7 +3832,7 @@ static code_holder_t *get_last_code_holder (MIR_context_t ctx, size_t size) {
 }
 
 void _MIR_flush_code_cache (void *start, void *bound) {
-#if defined(__GNUC__) && !defined(__MIRC__)
+#if defined(__GNUC__) && !defined(__MIRC__) &&  !defined(__wasm__)
   __builtin___clear_cache (start, bound);
 #endif
 }
@@ -6144,9 +6144,9 @@ void _MIR_dump_code (const char *name, int index, uint8_t *code, size_t code_len
   fclose (bf);
   sprintf (command,
            "gcc -c -o %s.o %s 2>&1 && objcopy --update-section .text=%s %s.o && objdump "
-           "--adjust-vma=0x%llx -d %s.o; rm -f "
+           "--adjust-vma=0x%" PRIxPTR " -d %s.o; rm -f "
            "%s.o %s %s",
-           cfname, cfname, bfname, cfname, (unsigned long long) code, cfname, cfname, cfname,
+           cfname, cfname, bfname, cfname, (uintptr_t) code, cfname, cfname, cfname,
            bfname);
 #endif
   fprintf (stderr, "%s\n", command);
@@ -6157,7 +6157,9 @@ void _MIR_dump_code (const char *name, int index, uint8_t *code, size_t code_len
 
 /* New Page */
 
-#if defined(__x86_64__) || defined(_M_AMD64)
+#if defined(__i686__) || defined(__wasm32__)
+#include "mir-x86_64.c"
+#elif defined(__x86_64__) || defined(_M_AMD64)
 #include "mir-x86_64.c"
 #elif defined(__aarch64__)
 #include "mir-aarch64.c"

--- a/mir.h
+++ b/mir.h
@@ -215,7 +215,7 @@ typedef uint8_t MIR_scale_t; /* Index reg scale in memory */
 
 #define MIR_MAX_SCALE UINT8_MAX
 
-typedef int64_t MIR_disp_t; /* Address displacement in memory */
+typedef intptr_t MIR_disp_t; /* Address displacement in memory */
 
 /* Register number (> 0).  A register always contain only one type
    value: integer, float, or (long) double.  Register numbers in insn
@@ -594,8 +594,8 @@ extern void MIR_link (MIR_context_t ctx, void (*set_interface) (MIR_context_t ct
 typedef union {
   MIR_insn_code_t ic;
   void *a;
-  int64_t i;
-  uint64_t u;
+  intptr_t i;
+  uintptr_t u;
   float f;
   double d;
   long double ld;

--- a/mk-wasm.sh
+++ b/mk-wasm.sh
@@ -1,0 +1,1 @@
+emsdk-env emcc -I. -MMD -MP -fPIC -g -std=gnu11 -Wno-abi -fsigned-char -O3 -DNDEBUG mir.c mir-gen.c c2mir/c2mir.c c2mir/c2mir-driver.c -lm -ldl -lpthread -o c2m.wasm


### PR DESCRIPTION
With this changes we can build on linux with `-m32` or emsdk for wasm, when building normally for 64 bits it pass all tests.
This is necessary for any attempt to build bootstrap/code generators for 32 bits (including wasm). 