### PR TITLE
Shorten code by removing redundant MOVs on X86.

### DIFF
--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -1057,7 +1057,7 @@ static void target_machinize (gen_ctx_t gen_ctx) {
       /* We can access only 4 regs in setxx -- use ax as the result: */
       MIR_op_t areg_op = _MIR_new_hard_reg_op (ctx, AX_HARD_REG);
 
-      new_insn = MIR_new_insn (ctx, MIR_MOV, insn->ops[0], areg_op);
+      new_insn = MIR_new_insn (ctx, MIR_UEXT8, insn->ops[0], areg_op);
       gen_add_insn_after (gen_ctx, insn, new_insn);
       insn->ops[0] = areg_op;
       /* Following conditional branches are changed to correctly process unordered numbers: */
@@ -1421,12 +1421,12 @@ struct pattern {
 
 /* cmp ...; setx r0; movzbl r0,r0: */
 #define CMP0(ICODE, SUFF, PREF, SETX)                                                            \
-  {ICODE##SUFF, "t r r", #PREF " 3B r1 R2;" SETX " R0;X 0F B6 r0 R0"},        /* cmp r1,r2;...*/ \
-    {ICODE##SUFF, "t r m3", #PREF " 3B r1 m2;" SETX " R0;X 0F B6 r0 R0"},     /* cmp r1,m2;...*/ \
-    {ICODE##SUFF, "t r i0", #PREF " 83 /7 R1 i2;" SETX " R0;X 0F B6 r0 R0"},  /* cmp r1,i2;...*/ \
-    {ICODE##SUFF, "t r i2", #PREF " 81 /7 R1 I2;" SETX " R0;X 0F B6 r0 R0"},  /* cmp r1,i2;...*/ \
-    {ICODE##SUFF, "t m3 i0", #PREF " 83 /7 m1 i2;" SETX " R0;X 0F B6 r0 R0"}, /* cmp m1,i2;...*/ \
-    {ICODE##SUFF, "t m3 i2", #PREF " 81 /7 m1 I2;" SETX " R0;X 0F B6 r0 R0"}, /* cmp m1,i2;...*/
+  {ICODE##SUFF, "t r r", #PREF " 3B r1 R2;" SETX " R0"},        /* cmp r1,r2;...*/ \
+    {ICODE##SUFF, "t r m3", #PREF " 3B r1 m2;" SETX " R0"},     /* cmp r1,m2;...*/ \
+    {ICODE##SUFF, "t r i0", #PREF " 83 /7 R1 i2;" SETX " R0"},  /* cmp r1,i2;...*/ \
+    {ICODE##SUFF, "t r i2", #PREF " 81 /7 R1 I2;" SETX " R0"},  /* cmp r1,i2;...*/ \
+    {ICODE##SUFF, "t m3 i0", #PREF " 83 /7 m1 i2;" SETX " R0"}, /* cmp m1,i2;...*/ \
+    {ICODE##SUFF, "t m3 i2", #PREF " 81 /7 m1 I2;" SETX " R0"}, /* cmp m1,i2;...*/
 
 #define CMP(ICODE, SET_OPCODE)  \
   CMP0 (ICODE, , X, SET_OPCODE) \


### PR DESCRIPTION
My code is very heavy on the compare family of insns. The added move after each is not needed, as we can put the result in the right place while we do the extend.

Tests pass. 