### PR TITLE
__GNU_LIBRARY__ isn't good in mirc_x86_64_stdarg.h

### DIFF
--- a/c2mir/x86_64/mirc_x86_64_stdarg.h
+++ b/c2mir/x86_64/mirc_x86_64_stdarg.h
@@ -11,7 +11,7 @@ static char stdarg_str[]
     "typedef __darwin_va_list va_list;\n"
 #elif defined(__WIN32)
     "typedef char *va_list;\n"
-#elif defined(__GNU_LIBRARY__)
+#else
     "typedef struct {\n"
     "  unsigned int gp_offset;\n"
     "  unsigned int fp_offset;\n"


### PR DESCRIPTION
I would like you to see details on #321, but let me report it again.

I found some errors in c2m.exe on Windows, and it caused by the file of mirc_x86_64_stdarg.h. At the beginning, I felt some mistakes with the macro of `__WIN32` because MSVC doesn't have `__WIN32` and it has `_WIN32` instead. However, it has another error when I replaced it by `_WIN32`.

When I digged into the source file, this macro's branch has no `#else` clause and `__WIN32` macro also doesn't work, so the frst problem has occurred. But even if I replaced it by `_WIN32`, the `__va_start` macro doesn't work by the error of not found on c2m.exe on Windows, that's why the second problem has occurred.

At least, this macro's branch has no `#else` clause, so it needs `#else` clause anyway, and now I am trying to find the correct fix but I didn't find anything so far. Therefore, this fix could be better as a workaround, so could you make it back to `#else`? My project is going well with this fix so far.

Thank you so much in advance.
