### PR TITLE
Export symbols in shared library on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ target_link_libraries(mir_static PRIVATE mir)
 
 # ------------------ LIBMIR SO --------------------
 add_library(mir_shared SHARED)
+if(WIN32)
+  set_target_properties(mir_shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+endif()
 target_link_libraries(mir_shared PRIVATE mir)
 
 # ------------------ C2M --------------------------


### PR DESCRIPTION
Symbols in shared libraries are not imported and exported by default on Windows. For exporting, I added the property WINDOWS_EXPORT_ALL_SYMBOLS to target mir_shared. CMake doesn't provide a way to import all symbols in a shared library, for importing symbols properly, __declspec(dllimport) is needed. Otherwise there will be a redundant jmp instruction, though the program still works. Currently I'm using `#define extern __declspec(dllimport) extern`, hope there will be a proper fix.