### PR TITLE
Use time (shell builtin) when benchmarking

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -706,10 +706,10 @@ gen-bench2: $(BUILD_DIR)/c2m # Ignore M1 MacOs as it needs another procedure to 
 	  echo +++++ Compiling and generating all code for c2m: +++++;\
 	  for i in 0 1 2 3;do \
 	    echo === Optimization level $$i:;\
-            echo 'int main () {return 0;}'\
-	    | /usr/bin/time $(BUILD_DIR)/c2m -O$$i -Dx86_64 -I$(SRC_DIR) $(SRC_DIR)/mir-gen.c $(SRC_DIR)/c2mir/c2mir.c\
-	                                                      $(SRC_DIR)/c2mir/c2mir-driver.c $(SRC_DIR)/mir.c -el -i;\
-	    rm -f a.bmir;\
+        echo 'int main () {return 0;}' > a.c;\
+	    time $(BUILD_DIR)/c2m -O$$i -Dx86_64 -I$(SRC_DIR) $(SRC_DIR)/mir-gen.c $(SRC_DIR)/c2mir/c2mir.c\
+	                                                      $(SRC_DIR)/c2mir/c2mir-driver.c $(SRC_DIR)/mir.c -el -i < a.c;\
+	    rm -f a.c a.bmir;\
 	  done;\
 	fi
 


### PR DESCRIPTION
target shell: GNU bash, version 5.2.21(1)-release
`time` is a built in, not a command. `xxx | time xxx` also doesn't work.

This commit fixes the issue.