### PR TITLE
Open binary files in binary mode

### DIFF
--- a/adt-tests/mir-reduce-test.c
+++ b/adt-tests/mir-reduce-test.c
@@ -46,7 +46,7 @@ int main (int argc, const char *argv[]) {
   size_t i, n;
   double start = real_usec_time ();
 
-  if (argc != 2 || (input_file = fopen (argv[1], "r")) == NULL) {
+  if (argc != 2 || (input_file = fopen (argv[1], "rb")) == NULL) {
     fprintf (stderr, "usage: %s <inputfile>\n", argv[0]);
     return 1;
   }

--- a/c2mir/c2mir-driver.c
+++ b/c2mir/c2mir-driver.c
@@ -223,7 +223,7 @@ static void *open_lib (const char *dir, const char *name) {
   if ((res = dlopen (VARR_ADDR (char, temp_string), RTLD_LAZY)) == NULL) {
 #ifndef _WIN32
     FILE *f;
-    if ((f = fopen (VARR_ADDR (char, temp_string), "r")) != NULL) {
+    if ((f = fopen (VARR_ADDR (char, temp_string), "rb")) != NULL) {
       fclose (f);
       fprintf (stderr, "loading %s:%s\n", VARR_ADDR (char, temp_string), dlerror ());
     }

--- a/mir-bin-run.c
+++ b/mir-bin-run.c
@@ -149,7 +149,7 @@ static void *open_lib (const char *dir, const char *name) {
   VARR_PUSH (char, temp_string, 0);
   if ((res = dlopen (VARR_ADDR (char, temp_string), RTLD_LAZY)) == NULL) {
 #ifndef _WIN32
-    if ((f = fopen (VARR_ADDR (char, temp_string), "r")) != NULL) {
+    if ((f = fopen (VARR_ADDR (char, temp_string), "rb")) != NULL) {
       fclose (f);
       fprintf (stderr, "loading %s:%s\n", VARR_ADDR (char, temp_string), dlerror ());
     }
@@ -303,7 +303,7 @@ int main (int argc, char **argv, char **envp) {
   MIR_item_t main_func = NULL;
 
   MIR_context_t mctx = MIR_init ();
-  FILE *mir_file = fopen (argv[1], "r");
+  FILE *mir_file = fopen (argv[1], "rb");
   if (!mir_file) {
     fprintf (stderr, "failed to open file '%s'\n", argv[1]);
     return 1;

--- a/mir-tests/test-read.h
+++ b/mir-tests/test-read.h
@@ -3,7 +3,7 @@ static char *read_file (const char *name) {
   size_t flen, rlen;
   char *str;
 
-  if ((f = fopen (name, "r")) == NULL) {
+  if ((f = fopen (name, "rb")) == NULL) {
     perror (name);
     exit (1);
   }

--- a/mir-utils/b2ctab.c
+++ b/mir-utils/b2ctab.c
@@ -6,6 +6,9 @@
 /* <stdio.h> provides _fileno */
 #include <fcntl.h> /* provides _O_BINARY */
 #include <io.h>    /* provides _setmode */
+#define set_filemode_binary(F) _setmode (_fileno (F), _O_BINARY)
+#else
+#define set_filemode_binary(F) 0
 #endif
 
 static size_t output_mir_code_byte_num;
@@ -20,10 +23,7 @@ static int output_mir_code_byte (MIR_context_t ctx MIR_UNUSED, uint8_t byte) {
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
 
-#ifdef _WIN32
-  if (_setmode (_fileno (stdin), _O_BINARY) == -1) return 1;
-#endif
-
+  if (set_filemode_binary (stdin) == -1) return 1;
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-binary-file  > C-file\n", argv[1]);
     return 1;

--- a/mir-utils/b2ctab.c
+++ b/mir-utils/b2ctab.c
@@ -2,6 +2,12 @@
 
 #include "mir.h"
 
+#ifdef _WIN32
+/* <stdio.h> provides _fileno */
+#include <fcntl.h> /* provides _O_BINARY */
+#include <io.h>    /* provides _setmode */
+#endif
+
 static size_t output_mir_code_byte_num;
 static FILE *output_mir_code_file;
 
@@ -13,6 +19,10 @@ static int output_mir_code_byte (MIR_context_t ctx MIR_UNUSED, uint8_t byte) {
 
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
+
+#ifdef _WIN32
+  if (_setmode (_fileno (stdin), _O_BINARY) == -1) return 1;
+#endif
 
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-binary-file  > C-file\n", argv[1]);

--- a/mir-utils/b2m.c
+++ b/mir-utils/b2m.c
@@ -1,8 +1,19 @@
 /* Transform mir binary form from stdin into mir text to stdout.  */
 
 #include "mir.h"
+
+#ifdef _WIN32
+/* <stdio.h> provides _fileno */
+#include <fcntl.h> /* provides _O_BINARY */
+#include <io.h>    /* provides _setmode */
+#endif
+
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
+
+#ifdef _WIN32
+  if (_setmode (_fileno (stdin), _O_BINARY) == -1) return 1;
+#endif
 
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-binary-file  > mir-text-file\n", argv[1]);

--- a/mir-utils/b2m.c
+++ b/mir-utils/b2m.c
@@ -6,15 +6,15 @@
 /* <stdio.h> provides _fileno */
 #include <fcntl.h> /* provides _O_BINARY */
 #include <io.h>    /* provides _setmode */
+#define set_filemode_binary(F) _setmode (_fileno (F), _O_BINARY)
+#else
+#define set_filemode_binary(F) 0
 #endif
 
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
 
-#ifdef _WIN32
-  if (_setmode (_fileno (stdin), _O_BINARY) == -1) return 1;
-#endif
-
+  if (set_filemode_binary (stdin) == -1) return 1;
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-binary-file  > mir-text-file\n", argv[1]);
     return 1;

--- a/mir-utils/m2b.c
+++ b/mir-utils/m2b.c
@@ -3,12 +3,22 @@
 
 #include "mir.h"
 
+#ifdef _WIN32
+/* <stdio.h> provides _fileno */
+#include <fcntl.h> /* provides _O_BINARY */
+#include <io.h>    /* provides _setmode */
+#endif
+
 DEF_VARR (char);
 
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
   VARR (char) * str;
   int c;
+
+#ifdef _WIN32
+  if (_setmode (_fileno (stdout), _O_BINARY) == -1) return 1;
+#endif
 
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-text-file > mir-binary-file\n", argv[1]);

--- a/mir-utils/m2b.c
+++ b/mir-utils/m2b.c
@@ -7,6 +7,9 @@
 /* <stdio.h> provides _fileno */
 #include <fcntl.h> /* provides _O_BINARY */
 #include <io.h>    /* provides _setmode */
+#define set_filemode_binary(F) _setmode (_fileno (F), _O_BINARY)
+#else
+#define set_filemode_binary(F) 0
 #endif
 
 DEF_VARR (char);
@@ -16,10 +19,7 @@ int main (int argc, char *argv[]) {
   VARR (char) * str;
   int c;
 
-#ifdef _WIN32
-  if (_setmode (_fileno (stdout), _O_BINARY) == -1) return 1;
-#endif
-
+  if (set_filemode_binary (stdout) == -1) return 1;
   if (argc != 1) {
     fprintf (stderr, "Usage: %s < mir-text-file > mir-binary-file\n", argv[1]);
     return 1;

--- a/mir.c
+++ b/mir.c
@@ -6906,7 +6906,7 @@ void _MIR_dump_code (const char *name, uint8_t *code, size_t code_len) {
 #endif
 #else
   sprintf (bfname, "_mir_%lu.bin", (unsigned long) getpid ());
-  if ((bf = fopen (bfname, "w")) == NULL) return;
+  if ((bf = fopen (bfname, "wb")) == NULL) return;
   fprintf (f, "void code (void) {}\n");
   for (i = 0; i < code_len; i++) fputc (code[i], bf);
   fclose (f);


### PR DESCRIPTION
This fixes newline-conversion issues on Windows. Otherwise, I'm not able to run compiled files. This does not change `fopen`s that appear to be only used for text files.