### PR TITLE
fixed CMakeLists.txt:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ target_include_directories(mir PRIVATE ${PROJECT_SOURCE_DIR})
 if(Threads_FOUND)
   target_compile_definitions(mir PUBLIC "MIR_PARALLEL_GEN")
 endif()
+if(UNIX)
+	target_link_libraries(mir m)
+endif()
 
 # ------------------ LIBMIR -----------------------
 add_library(mir_static STATIC)
@@ -65,9 +68,9 @@ target_link_libraries(c2m mir ${CMAKE_DL_LIBS} )
 
 # ------------------ MIR RUN ----------------------
 
-add_executable (mir-run "mir-run.c")
-target_include_directories (mir-run PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(mir-run mir ${CMAKE_DL_LIBS} )
+#add_executable (mir-run "mir-run.c")
+#target_include_directories (mir-run PRIVATE ${PROJECT_SOURCE_DIR})
+#target_link_libraries(mir-run mir ${CMAKE_DL_LIBS} )
 
 # ------------------ MIR utils --------------------
 add_executable (m2b "mir-utils/m2b.c")


### PR DESCRIPTION
cmake failed for me (master & 1.0.0-release):

- mir-run.c is missing from the repository -> deactivated target 'mir-run'
- tried to compile with clang like this
`CC=clang CXX=clang++ cmake ..`
but got undefined symbol 'nanl' error

>   [  5%] Built target mir
>    [  6%] Built target mir_static
>    [  8%] Built target mir_shared
>    [ 10%] Linking C executable c2m
>    /usr/bin/ld: CMakeFiles/mir.dir/c2mir/c2mir.c.o: in function \`check_assign_op\':
>    c2mir.c:(.text+0x169e9): undefined reference to `nanl'
>    clang: error: linker command failed with exit code 1 (use -v to see invocation)
>    make[2]: *** [CMakeFiles/c2m.dir/build.make:103: c2m] Error 1
>    make[1]: *** [CMakeFiles/Makefile2:977: CMakeFiles/c2m.dir/all] Error 2
>    make: *** [Makefile:101: all] Error 

therefore added '-lm' to target 'mir'