### PR TITLE
update the x86_64 ABI link.

### DIFF
--- a/c2mir/x86_64/cx86_64-ABI-code.c
+++ b/c2mir/x86_64/cx86_64-ABI-code.c
@@ -4,8 +4,8 @@
 */
 
 /* See https://gitlab.com/x86-psABIs/x86-64-ABI.
- * We use MIR_T_UNDEF for MEMORY.
- */
+   We use MIR_T_UNDEF for MEMORY.
+*/
 
 enum add_arg_class { NO_CLASS = MIR_T_BOUND + 1, X87UP_CLASS };
 

--- a/c2mir/x86_64/cx86_64-ABI-code.c
+++ b/c2mir/x86_64/cx86_64-ABI-code.c
@@ -3,8 +3,9 @@
    x86_64 ABI target specific code.
 */
 
-/* See https://github.com/hjl-tools/x86-psABI/wiki/x86-64-psABI-1.0.pdf.  We use MIR_T_UNDEF for
-   MEMORY. */
+/* See https://gitlab.com/x86-psABIs/x86-64-ABI.
+ * We use MIR_T_UNDEF for MEMORY.
+ */
 
 enum add_arg_class { NO_CLASS = MIR_T_BOUND + 1, X87UP_CLASS };
 

--- a/c2mir/x86_64/cx86_64-code.c
+++ b/c2mir/x86_64/cx86_64-code.c
@@ -24,7 +24,7 @@ static string_include_t standard_includes[]
 #define ADJUST_VAR_ALIGNMENT(c2m_ctx, align, type) x86_adjust_var_alignment (c2m_ctx, align, type)
 
 static int x86_adjust_var_alignment (c2m_ctx_t c2m_ctx, int align, struct type *type) {
-  /* see https://www.uclibc.org/docs/psABI-x86_64.pdf */
+  /* see https://gitlab.com/x86-psABIs/x86-64-ABI */
   if (type->mode == TM_ARR && raw_type_size (c2m_ctx, type) >= 16) return 16;
   return align;
 }

--- a/c2mir/x86_64/mirc_x86_64_stdarg.h
+++ b/c2mir/x86_64/mirc_x86_64_stdarg.h
@@ -2,7 +2,7 @@
    Copyright (C) 2019-2024 Vladimir Makarov <vmakarov.gcc@gmail.com>.
 */
 
-/* See C11 7.16 and https://www.uclibc.org/docs/psABI-x86_64.pdf */
+/* See C11 7.16 and https://gitlab.com/x86-psABIs/x86-64-ABI */
 static char stdarg_str[]
   = "#ifndef __STDARG_H\n"
     "#define __STDARG_H\n"


### PR DESCRIPTION
The ABI document link for x86_64 in the codebase has appeared multiple times in various locations, all of which are outdated. The current ABI development repository has been relocated to GitLab. This PR updates the latest x86_64 ABI link.