### PR TITLE
Add support for custom allocators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.a
 /mir-run
 /build
+/.cache

--- a/CUSTOM-ALLOCATORS.md
+++ b/CUSTOM-ALLOCATORS.md
@@ -1,0 +1,198 @@
+# Custom Allocators
+
+In some environments, memory cannot / should not directly be managed by calls to `malloc`, `free` etc. for various reasons. To support this use case, MIR lets you provide user defined allocators. These can be supplied during context creation by calling `MIR_context_t MIR_init2 (MIR_alloc_t alloc, MIR_code_alloc_t code_alloc)`.
+
+Calling `MIR_context_t MIR_init (void)` instead without passing custom allocators will default to using the standard functions `malloc`, `free`, ..., as well as the operating systems default routines for memory mapping and protection.
+
+## User Guide
+
+The following sections are intended for users of MIR as a library. If you want to contribute to MIR directly, take a look at [the developer guide](#developer-guide).
+
+### General Purpose Allocators
+
+`MIR_alloc` is the general purpose allocator type defined by MIR, used for most allocations. Users wishing to provide a general prupose allocator need to define the following functions:
+
+- `void *malloc (size_t size, void *user_data)`
+- `void *calloc (size_t num, size_t size, void *user_data)`
+- `void *realloc (void *ptr, size_t old_size, size_t new_size, void *user_data)`
+- `void free (void *ptr, void *user_data)`
+
+These functions should follow the same semantics as the standard C functions of the same name. This includes the platform's alignment guarantees.
+
+> [!IMPORTANT]
+> The `realloc` function required by `MIR_alloc` slightly differs from its standard C counterpart in that it takes an additional parameter `old_size`, which denotes the size of the allocation `realloc` is invoked on.
+> This was introduced to support allocators that do not provide `realloc` natively, as shown in [the example below](#example).
+> Allocators that do support `realloc` out of the box can ignore this parameter or use it for validation purposes.
+
+> [!IMPORTANT]
+> Some allocator implementations (such as `std::pmr::(un)synchronized_pool_resource` in libstd++ / libc++) require users to provide the exact size of the allocation to calls of their deallocation function.
+> This approach turns out to be largely infeasible for MIR as there are countless allocations whose size is dynamically determined, which would (in contrast to the `realloc` compromise outlined above) require a lot of additional bookkeeping on MIR's part.
+> Users wishing to use such an allocator with MIR may need to implement this additional bookkeeping themselves.
+
+Apart from the pointers and sizes one would expected, all functions additionally accept a `user_data` parameter. This can be used to pass additional context as outlined in [the example below](#example).
+
+> [!WARNING]
+> The `MIR_alloc` instance passed to `MIR_init2` must have a lifetime greater or equal to the resulting `MIR_context`, i.e. live at least as long as the subsequent call to `MIR_finish`.
+> The `MIR_alloc` instance being destroyed or going out of scope beforehand may result in undefined behavior.
+
+### Executable Code Allocators
+
+`MIR_code_alloc` is the executable code related allocator type defined by MIR. It is used to map and unmap pages of memory, as well as manipulate their protection. Users wishing to provide an executable code allocator need to define the following functions:
+
+- `void *(*mem_map) (size_t len, void *user_data)`: allocate and zero `len` bytes of memory (see `mmap` / `VirtualAlloc`)
+- `int (*mem_unmap) (void *ptr, size_t len, void *user_data)`: free `len` bytes of memory at `ptr`, previously allocated by a call to `mem_map` (see `munmap` / `VirtualFree`)
+- `int (*mem_protect) (void *ptr, size_t len, MIR_mem_protect_t prot, void *user_data)`: change the protection of memory identified by `ptr` and `len` according to the flags specified in `prot` (see `mprotect` / `VirtualProtect`)
+
+Possible values for `prot` are contained in enum `MIR_mem_protect_t` (`PROT_READ_EXEC` and `PROT_WRITE_EXEC`).
+
+Similar to `MIR_alloc`, `MIR_code_alloc` lets users pass `user_data` to the different functions.
+
+MIR will not try to directly write to or execute memory returned by `mem_map`, but will instead call `mem_protect` with appropriate flags beforehand.
+
+> [!WARNING]
+> The `MIR_code_alloc` instance passed to `MIR_init2` must have a lifetime greater or equal to the resulting `MIR_context`, i.e. live at least as long as the subsequent call to `MIR_finish`.
+> The `MIR_code_alloc` instance being destroyed or going out of scope beforehand may result in undefined behavior.
+
+### Thread Safety
+
+Users intending to use custom allocators while calling MIR functions from different threads need to ensure that their provided functions are thread safe.
+
+### Example
+
+This example showcases an approach to wrap a given stateful allocator interface, `my_allocator`, for use with MIR.
+
+It uses some C++11/14 features, but can be easily adapted to work with older C++ standards.
+
+```cpp
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "mir.h"
+
+template<typename T>
+inline constexpr T align(T value, uint64_t alignment)
+{
+    // sadly `std::align` is only useful for very specific use cases,
+    // hence we roll our own alignment routine:
+    return (T) ((((uint64_t) value) + alignment - 1) & ~(alignment - 1));
+}
+
+class my_allocator
+{
+public:
+    virtual ~my_allocator() = default;
+    void *allocate(size_t size) = 0;
+    void deallocate(void *ptr) = 0;
+};
+
+class context
+{
+public:
+    context(my_allocator &allocator)
+        : _allocator{allocator}
+        , _mir_alloc{&context::do_malloc,
+                     &context::do_calloc,
+                     &context::do_realloc,
+                     &context::do_free,
+                     this} // user_data
+        , _mir_context{MIR_init2(&_mir_alloc, nullptr)}
+    {
+    }
+
+    ~context()
+    {
+        if (_mir_context != nullptr)
+        {
+            MIR_finish(_mir_context);
+        }
+    }
+
+    // ...
+
+private:
+    static context &context_from_user_data(void *user_data)
+    {
+        return *static_cast<context *>(user_data);
+    }
+
+    static void *do_malloc(size_t size, void *user_data)
+    {
+        auto &self = context_from_user_data(user_data);
+        return self._allocator.allocate(size);
+    }
+
+    static void *do_calloc(size_t num, size_t size, void *user_data)
+    {
+        auto &self = context_from_user_data(user_data);
+        const size_t aligned_size = align(size, alignof(std::max_align_t));
+        const size_t total_size = aligned_size * num;
+        void *const ptr = self._allocator.allocate(total_size);
+        std::memset(ptr, 0, total_size);
+        return ptr;
+    }
+
+    static void *do_realloc(void *ptr, size_t old_size, size_t new_size, void *user_data)
+    {
+        auto &self = context_from_user_data(user_data);
+        void *const new_ptr = self._allocator.allocate(size);
+        // if the `my_alloctor` interface supports a `realloc` method natively,
+        // we could simply call it here;
+        // instead, for the purpose of this example, we have to rely on the size
+        // of the previous allocation to be able to translate `realloc` into
+        // `allocate` - `memcpy` - `deallocate`:
+        std::memcpy(new_ptr, ptr, old_size);
+        self._allocator.deallocate(ptr);
+        return new_ptr;
+    }
+
+    static void do_free (void *ptr, void *user_data)
+    {
+        if (ptr == nullptr)
+        {
+            return;
+        }
+        auto &self = context_from_user_data(user_data);
+        self._allocator.deallocate(ptr);
+    }
+
+private:
+    my_allocator &_allocator;
+    MIR_alloc _mir_alloc;
+    MIR_context_t _mir_context;
+};
+```
+
+## Developer Guide
+
+The following sections are intended for contributors to MIR.
+
+### Overview
+
+Pointers to allocators are stored in fields `alloc` and `code_alloc` of struct `MIR_context`. These pointers are always valid, even if the user did not provide any or only some allocators explicitly (in this case, default allocators are used where needed).
+
+Passing the executable code allocator only to `MIR_gen_init` may seem conceptually more sound, but does not seem to work in practice as the interpreter relies on some of the code generation infrastructure as well.
+
+The vector implementation in [`mir-varr.h`](mir-varr.h) keeps an additional pointer to the allocator it was created with. While this slightly increases its memory footprint, the alternative (passing a `MIR_alloc_t` to each and every of its operations) made for a very verbose API.
+
+### Executables shipped with MIR
+
+Custom allocators are mostly relevant for uses of MIR as a library in some other project. In case you are working on some executable specific part of MIR, e.g. tests, you can mostly ignore custom allocators and simply call `MIR_init` instead of `MIR_init2` as before.
+
+In case you are testing / using some of the lower level APIs that require you to explicitly pass an allocator, such as the [`VARR`](mir-varr.h) or [`HTAB`](mir-htab.h) implementations, you can include [`mir-alloc-default.c`](mir-alloc-default.c) into your translation unit and simply pass `&default_alloc` where required. The same goes for code allocators and [`mir-code-alloc-default.c`](mir-code-alloc-default.c) / `&default_code_alloc` respectively.
+
+### MIR as a Library
+
+Code shipped as part of the main MIR library should avoid calling standard memory management routines such as `malloc`, `free`, `mmap`, ... directly and instead use the following allocator aware replacements (located in [`mir-alloc.h`](mir-alloc.h) and [`mir-code-alloc.h`](mir-code-alloc.h) respectively):
+
+- `void *MIR_malloc (MIR_alloc_t alloc, size_t size)`
+- `void *MIR_calloc (MIR_alloc_t alloc, size_t num, size_t size)`
+- `void *MIR_realloc (MIR_alloc_t alloc,  void *ptr, size_t old_size, size_t new_size)`
+- `void MIR_free (MIR_alloc_t alloc, void *ptr)`
+- `void *MIR_mem_map (MIR_code_alloc_t code_alloc, size_t len)`
+- `int MIR_mem_unmap (MIR_code_alloc_t code_alloc, void *ptr, size_t len)`
+- `int MIR_mem_protect (MIR_code_alloc_t code_alloc, void *ptr, size_t len, MIR_mem_protect_t prot)`
+
+Suitable allocators can usually be obtained directly from the `MIR_context` (fields `alloc` and `code_alloc`), or by calling `MIR_alloc_t MIR_get_alloc (MIR_context_t ctx)`.
+
+In case no `MIR_context` is available in a function where you require an allocator (neither directly nor indirectly through other sub-contexts such as `gen_ctx_t`), consider taking a `MIR_alloc_t` (or `MIR_code_alloc_t`) as a parameter.

--- a/MIR.md
+++ b/MIR.md
@@ -10,13 +10,14 @@
   * MIR API code has an implicit state called by MIR context
   * MIR context is represented by data of `MIR_context_t`
   * MIR context is created by function `MIR_context_t MIR_init (void)`
-  * Every MIR API function (except for `MIR_init`) requires MIR context passed through the first argument of type `MIR_context_t`
+  * In case you want to use custom allocators, use `MIR_context_t MIR_init2 (MIR_alloc_t, MIR_code_alloc_t)` instead (see [here](CUSTOM-ALLOCATORS.md) for more details)
+  * Every MIR API function (except for `MIR_init` / `MIR_init2`) requires MIR context passed through the first argument of type `MIR_context_t`
   * You can use MIR functions in different threads without any synchronization
     if they work with different contexts in each thread
 
 ## MIR program
    * MIR program consists of MIR **modules**
-   * To start work with MIR program, you should first call API function `MIR_init`
+   * To start work with MIR program, you should first call API function `MIR_init` / `MIR_init2`
    * API function `MIR_finish (MIR_context_t ctx)` should be called last.  It frees all internal data used to work with MIR program and all IR (insns, functions, items, and modules) created in this context
    * API function `MIR_output (MIR_context_t ctx, FILE *f)` outputs MIR textual representation of the program into given file
    * API function `MIR_scan_string (MIR_context_t ctx, const char *str)` reads textual MIR representation given by a string

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Disclaimer
    * **There is absolutely no warranty that the code will work for any tests except ones given here and on platforms
      other than x86_64 Linux/OSX, aarch64 Linux/OSX(Apple M1), and ppc64le/s390x/riscv64 Linux**
-  
+
 ## MIR
   * MIR is strongly typed IR
   * MIR can represent machine 32-bit and 64-bit insns of different architectures
@@ -178,7 +178,7 @@ ex100:    func v, 0
   * Running code from the above example could look like the following (here `m1` and `m2` are modules
     `m_sieve` and `m_e100`, `func` is function `ex100`, `sieve` is function `sieve`):
 ```c
-    /* ctx is a context created by MIR_init */
+    /* ctx is a context created by MIR_init / MIR_init2 */
     MIR_load_module (ctx, m1); MIR_load_module (ctx, m2);
     MIR_load_external (ctx, "printf", printf);
     MIR_link (ctx, MIR_set_interp_interface, import_resolver);
@@ -316,8 +316,8 @@ The executable is "configurable" with environment variables:
    * Files `mir-gen-x86_64.c`, `mir-gen-aarch64.c`, `mir-gen-ppc64.c`, `mir-gen-s390x.c`,
    and `mir-gen-riscv64.c` is machine dependent code of JIT compiler
  * Files `mir-<target>.c` contain simple machine dependent code common for interpreter and
-   JIT compiler 
- * Files `mir-<target>.h` contain declarations common for interpreter and JIT compiler 
+   JIT compiler
+ * Files `mir-<target>.h` contain declarations common for interpreter and JIT compiler
  * Files `mir2c/mir2c.h` and `mir2c/mir2c.c` contain code for MIR to C compiler.  The generated code might be not portable
  * Files `c2mir/c2mir.h`, `c2mir/c2mir.c`, `c2mir/c2mir-driver.c`, and `c2mir/mirc.h` contain code for
    C to MIR compiler.  Files in directories `c2mir/x86_64` and `c2mir/aarch64`, `c2mir/ppc64`, `c2mir/s390x`,
@@ -346,7 +346,7 @@ The executable is "configurable" with environment variables:
    [1] is based on wall time of compilation of C sieve code (w/o any include file and with
    using memory file system for GCC) and the corresponding MIR sieve code by MIR-interpreter
    and MIR-generator with optimization level 2
-    
+
    [2] is based on the best wall time of 10 runs with used MIR-generator optimization level 2
 
    [3] is based on stripped sizes of cc1 for GCC and MIR core and interpreter or generator for MIR
@@ -388,7 +388,7 @@ The executable is "configurable" with environment variables:
     * wasi LLVM is a C to webassember clang compiler (11.0.0) with wasmer (1.0.2) based on LLVM backend
     * wasi singlepass is a C to webassember clang compiler (11.0.0) with wasmer (1.0.2) based on singlepass backend
     * wasi wasmtime is a C to webassember clang compiler (11.0.0) with wasmtime (0.26.0) runtime based on cranelift backend
-    
+
     |                                                  |  Average  |   Geomean |
     |--------------------------------------------------|-----------|-----------|
     | gcc -O2                                          |    1.00   |   1.00    |

--- a/adt-tests/mir-bitmap-test.c
+++ b/adt-tests/mir-bitmap-test.c
@@ -1,13 +1,17 @@
 #include "mir-bitmap.h"
+#include "mir-alloc.h"
+
+#include "mir-alloc-default.c"
 
 int main (void) {
+  MIR_alloc_t alloc = &default_alloc;
   int status;
   bitmap_t b1, b2, b3, b4;
 
-  b1 = bitmap_create ();
-  b2 = bitmap_create ();
-  b3 = bitmap_create ();
-  b4 = bitmap_create ();
+  b1 = bitmap_create (alloc);
+  b2 = bitmap_create (alloc);
+  b3 = bitmap_create (alloc);
+  b4 = bitmap_create (alloc);
   status = bitmap_empty_p (b1);
   status &= bitmap_bit_count (b1) == 0;
 

--- a/adt-tests/mir-htab-test.c
+++ b/adt-tests/mir-htab-test.c
@@ -1,4 +1,7 @@
 #include "mir-htab.h"
+#include "mir-alloc.h"
+
+#include "mir-alloc-default.c"
 
 static int status = 1;
 
@@ -24,11 +27,14 @@ static void add (int i, void *arg) {
   (*sum) += i;
 }
 
+
+
 int main (void) {
+  MIR_alloc_t alloc = &default_alloc;
   int i, collisions, iter, tab_el;
   HTAB (int) * htab;
 
-  HTAB_CREATE_WITH_FREE_FUNC (int, htab, 4, hash, eq, f, ARG);
+  HTAB_CREATE_WITH_FREE_FUNC (int, htab, alloc, 4, hash, eq, f, ARG);
   status &= HTAB_ELS_NUM (int, htab) == 0;
   for (iter = 0; iter < 10; iter++) {
     for (i = 0; i < 100; i++) {

--- a/adt-tests/mir-reduce-test.c
+++ b/adt-tests/mir-reduce-test.c
@@ -1,7 +1,10 @@
 #include <stdio.h>
+#include "mir-alloc.h"
 #include "mir-reduce.h"
 #include "mir-varr.h"
 #include "real-time.h"
+
+#include "mir-alloc-default.c"
 
 DEF_VARR (uint8_t);
 static VARR (uint8_t) * orig, *buf1, *buf2;
@@ -43,6 +46,7 @@ static size_t writer2 (const void *start, size_t len, void *aux_data) {
 }
 
 int main (int argc, const char *argv[]) {
+  MIR_alloc_t alloc = &default_alloc;
   size_t i, n;
   double start = real_usec_time ();
 
@@ -50,18 +54,18 @@ int main (int argc, const char *argv[]) {
     fprintf (stderr, "usage: %s <inputfile>\n", argv[0]);
     return 1;
   }
-  VARR_CREATE (uint8_t, orig, 0);
-  VARR_CREATE (uint8_t, buf1, 0);
-  if (!reduce_encode (reader1, writer1, NULL)) {
+  VARR_CREATE (uint8_t, orig, alloc, 0);
+  VARR_CREATE (uint8_t, buf1, alloc, 0);
+  if (!reduce_encode (alloc, reader1, writer1, NULL)) {
     fprintf (stderr, "Error in reducing input file!\n");
     return 1;
   }
   fprintf (stderr, "Compression:   original len = %llu, result = %llu, ration=%.2f, time=%.2fms\n",
            (unsigned long long) input_length1, (unsigned long long) output_length1,
            (input_length1 + 0.0) / output_length1, (real_usec_time () - start) / 1000.0);
-  VARR_CREATE (uint8_t, buf2, 0);
+  VARR_CREATE (uint8_t, buf2, alloc, 0);
   start = real_usec_time ();
-  if (!reduce_decode (reader2, writer2, NULL)) {
+  if (!reduce_decode (alloc, reader2, writer2, NULL)) {
     fprintf (stderr, "Corrupted input file!\n");
     return 1;
   }

--- a/adt-tests/mir-varr-test.c
+++ b/adt-tests/mir-varr-test.c
@@ -1,13 +1,17 @@
+#include "mir-alloc.h"
 #include "mir-varr.h"
+
+#include "mir-alloc-default.c"
 
 DEF_VARR (int);
 int main (void) {
+  MIR_alloc_t alloc = &default_alloc;
   int status, elem;
   VARR (int) * test;
   size_t ind;
   int arr[] = {1, 2, 3};
 
-  VARR_CREATE (int, test, 0);
+  VARR_CREATE (int, test, alloc, 0);
   status = VARR_LENGTH (int, test) == 0;
   VARR_PUSH (int, test, 42);
   status &= VARR_LAST (int, test) == 42;

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -22,6 +22,8 @@
 #include <setjmp.h>
 #include <math.h>
 #include <wchar.h>
+#include "mir-alloc.h"
+#include "mir.h"
 #include "time.h"
 
 #include "c2mir.h"
@@ -346,8 +348,13 @@ typedef struct {
 #error "undefined or unsupported generation target for C"
 #endif
 
+static inline MIR_alloc_t c2m_alloc (c2m_ctx_t c2m_ctx) {
+  return MIR_get_alloc (c2m_ctx->ctx);
+}
+
 static void *reg_malloc (c2m_ctx_t c2m_ctx, size_t s) {
-  void *mem = malloc (s);
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  void *mem = MIR_malloc (alloc, s);
 
   if (mem == NULL) alloc_error (c2m_ctx, "no memory");
   VARR_PUSH (void_ptr_t, reg_memory, mem);
@@ -355,7 +362,9 @@ static void *reg_malloc (c2m_ctx_t c2m_ctx, size_t s) {
 }
 
 static void reg_memory_pop (c2m_ctx_t c2m_ctx, size_t mark) {
-  while (VARR_LENGTH (void_ptr_t, reg_memory) > mark) free (VARR_POP (void_ptr_t, reg_memory));
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  while (VARR_LENGTH (void_ptr_t, reg_memory) > mark)
+    MIR_free (alloc, VARR_POP (void_ptr_t, reg_memory));
 }
 
 static size_t MIR_UNUSED reg_memory_mark (c2m_ctx_t c2m_ctx) {
@@ -366,7 +375,10 @@ static void reg_memory_finish (c2m_ctx_t c2m_ctx) {
   VARR_DESTROY (void_ptr_t, reg_memory);
 }
 
-static void reg_memory_init (c2m_ctx_t c2m_ctx) { VARR_CREATE (void_ptr_t, reg_memory, 4096); }
+static void reg_memory_init (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  VARR_CREATE (void_ptr_t, reg_memory, alloc, 4096);
+}
 
 static int char_is_signed_p (void) { return MIR_CHAR_MAX == MIR_SCHAR_MAX; }
 
@@ -388,8 +400,9 @@ static htab_hash_t str_key_hash (tab_str_t str, void *arg MIR_UNUSED) {
 static str_t uniq_cstr (c2m_ctx_t c2m_ctx, const char *str);
 
 static void str_init (c2m_ctx_t c2m_ctx) {
-  HTAB_CREATE (tab_str_t, str_tab, 1000, str_hash, str_eq, NULL);
-  HTAB_CREATE (tab_str_t, str_key_tab, 200, str_key_hash, str_key_eq, NULL);
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  HTAB_CREATE (tab_str_t, str_tab, alloc, 1000, str_hash, str_eq, NULL);
+  HTAB_CREATE (tab_str_t, str_key_tab, alloc, 200, str_key_hash, str_key_eq, NULL);
   empty_str = uniq_cstr (c2m_ctx, "");
 }
 
@@ -434,16 +447,20 @@ static void str_finish (c2m_ctx_t c2m_ctx) {
 }
 
 static void *c2mir_calloc (c2m_ctx_t c2m_ctx, size_t size) {
-  void *res = calloc (1, size);
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  void *res = MIR_calloc (alloc, 1, size);
 
   if (res == NULL) (*MIR_get_error_func (c2m_ctx->ctx)) (MIR_alloc_error, "no memory");
   return res;
 }
 
 void c2mir_init (MIR_context_t ctx) {
+  MIR_alloc_t alloc = MIR_get_alloc (ctx);
   struct c2m_ctx **c2m_ctx_ptr = c2m_ctx_loc (ctx), *c2m_ctx;
 
-  *c2m_ctx_ptr = c2m_ctx = c2mir_calloc (NULL, sizeof (struct c2m_ctx));
+  *c2m_ctx_ptr = c2m_ctx = MIR_calloc (alloc, 1, sizeof (struct c2m_ctx));
+  if (c2m_ctx == NULL) (*MIR_get_error_func (ctx)) (MIR_alloc_error, "no memory");
+
   c2m_ctx->ctx = ctx;
   reg_memory_init (c2m_ctx);
   str_init (c2m_ctx);
@@ -906,8 +923,9 @@ static void warning (c2m_ctx_t c2m_ctx, pos_t pos, const char *format, ...) {
 #define TAB_STOP 8
 
 static void init_streams (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   cs = eof_s = NULL;
-  VARR_CREATE (stream_t, streams, 32);
+  VARR_CREATE (stream_t, streams, alloc, 32);
 }
 
 static void free_stream (stream_t s) {
@@ -922,10 +940,10 @@ static void finish_streams (c2m_ctx_t c2m_ctx) {
   VARR_DESTROY (stream_t, streams);
 }
 
-static stream_t new_stream (FILE *f, const char *fname, int (*getc_func) (c2m_ctx_t)) {
-  stream_t s = malloc (sizeof (struct stream));
+static stream_t new_stream (MIR_alloc_t alloc, FILE *f, const char *fname, int (*getc_func) (c2m_ctx_t)) {
+  stream_t s = MIR_malloc (alloc, sizeof (struct stream));
 
-  VARR_CREATE (char, s->ln, 128);
+  VARR_CREATE (char, s->ln, alloc, 128);
   s->f = f;
   s->fname = s->pos.fname = fname;
   s->pos.lno = 0;
@@ -939,12 +957,13 @@ static stream_t new_stream (FILE *f, const char *fname, int (*getc_func) (c2m_ct
 static void add_stream (c2m_ctx_t c2m_ctx, FILE *f, const char *fname,
                         int (*getc_func) (c2m_ctx_t)) {
   assert (fname != NULL);
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   if (cs != NULL && cs->f != NULL && cs->f != stdin) {
     fgetpos (cs->f, &cs->fpos);
     fclose (cs->f);
     cs->f = NULL;
   }
-  cs = new_stream (f, fname, getc_func);
+  cs = new_stream (alloc, f, fname, getc_func);
   VARR_PUSH (stream_t, streams, cs);
 }
 
@@ -1051,8 +1070,9 @@ static void cs_unget (c2m_ctx_t c2m_ctx, int c) {
 
 static void set_string_stream (c2m_ctx_t c2m_ctx, const char *str, pos_t pos,
                                void (*transform) (const char *, VARR (char) *)) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   /* read from string str */
-  cs = new_stream (NULL, NULL, NULL);
+  cs = new_stream (alloc, NULL, NULL, NULL);
   VARR_PUSH (stream_t, streams, cs);
   cs->pos = pos;
   if (transform != NULL) {
@@ -2052,21 +2072,22 @@ static void new_std_macro (c2m_ctx_t c2m_ctx, const char *id_str) {
 }
 
 static void init_macros (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   VARR (token_t) * params;
 
-  VARR_CREATE (macro_t, macros, 2048);
-  HTAB_CREATE (macro_t, macro_tab, 2048, macro_hash, macro_eq, NULL);
+  VARR_CREATE (macro_t, macros, alloc, 2048);
+  HTAB_CREATE (macro_t, macro_tab, alloc, 2048, macro_hash, macro_eq, NULL);
   /* Standard macros : */
   new_std_macro (c2m_ctx, "__DATE__");
   new_std_macro (c2m_ctx, "__TIME__");
   new_std_macro (c2m_ctx, "__FILE__");
   new_std_macro (c2m_ctx, "__LINE__");
   if (!c2m_options->pedantic_p) {
-    VARR_CREATE (token_t, params, 1);
+    VARR_CREATE (token_t, params, alloc, 1);
     VARR_PUSH (token_t, params, new_id_token (c2m_ctx, no_pos, "$"));
     new_macro (c2m_ctx, new_id_token (c2m_ctx, no_pos, "__has_include"), params, NULL);
-    VARR_CREATE (token_t, params, 1);
+    VARR_CREATE (token_t, params, alloc, 1);
     VARR_PUSH (token_t, params, new_id_token (c2m_ctx, no_pos, "$"));
     new_macro (c2m_ctx, new_id_token (c2m_ctx, no_pos, "__has_builtin"), params, NULL);
   }
@@ -2102,14 +2123,14 @@ static void finish_macros (c2m_ctx_t c2m_ctx) {
   if (macro_tab != NULL) HTAB_DESTROY (macro_t, macro_tab);
 }
 
-static macro_call_t new_macro_call (macro_t m, pos_t pos) {
+static macro_call_t new_macro_call (MIR_alloc_t alloc, macro_t m, pos_t pos) {
   macro_call_t mc = malloc (sizeof (struct macro_call));
 
   mc->macro = m;
   mc->pos = pos;
   mc->repl_pos = 0;
   mc->args = NULL;
-  VARR_CREATE (token_t, mc->repl_buffer, 64);
+  VARR_CREATE (token_t, mc->repl_buffer, alloc, 64);
   return mc;
 }
 
@@ -2142,6 +2163,7 @@ static void pop_ifstate (c2m_ctx_t c2m_ctx) {
 }
 
 static void pre_init (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx;
   time_t t, time_loc;
   struct tm *tm, tm_loc MIR_UNUSED;
@@ -2165,12 +2187,12 @@ static void pre_init (c2m_ctx_t c2m_ctx) {
   date_str[strlen (date_str) - 1] = '\0';
   strcpy (time_str, time_str_repr + 1);
   time_str[strlen (time_str) - 1] = '\0';
-  VARR_CREATE (char_ptr_t, once_include_files, 64);
-  VARR_CREATE (token_t, temp_tokens, 128);
-  VARR_CREATE (token_t, output_buffer, 2048);
+  VARR_CREATE (char_ptr_t, once_include_files, alloc, 64);
+  VARR_CREATE (token_t, temp_tokens, alloc, 128);
+  VARR_CREATE (token_t, output_buffer, alloc, 2048);
   init_macros (c2m_ctx);
-  VARR_CREATE (ifstate_t, ifs, 512);
-  VARR_CREATE (macro_call_t, macro_call_stack, 512);
+  VARR_CREATE (ifstate_t, ifs, alloc, 512);
+  VARR_CREATE (macro_call_t, macro_call_stack, alloc, 512);
 }
 
 static void pre_finish (c2m_ctx_t c2m_ctx) {
@@ -2265,6 +2287,7 @@ static int replacement_eq_p (VARR (token_t) * r1, VARR (token_t) * r2) {
 }
 
 static void define (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   VARR (token_t) * repl, *params;
   token_t id, t;
@@ -2281,10 +2304,10 @@ static void define (c2m_ctx_t c2m_ctx) {
   }
   id = t;
   t = get_next_pptoken (c2m_ctx);
-  VARR_CREATE (token_t, repl, 64);
+  VARR_CREATE (token_t, repl, alloc, 64);
   params = NULL;
   if (t->code == '(') {
-    VARR_CREATE (token_t, params, 16);
+    VARR_CREATE (token_t, params, alloc, 16);
     t = get_next_pptoken (c2m_ctx); /* skip '(' */
     if (t->code == ' ') t = get_next_pptoken (c2m_ctx);
     if (t->code != ')') {
@@ -2579,6 +2602,7 @@ static void pop_macro_call (c2m_ctx_t c2m_ctx) {
 }
 
 static void find_args (c2m_ctx_t c2m_ctx, macro_call_t mc) { /* we have just read a parenthesis */
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   macro_t m;
   token_t t;
   int va_p, level = 0;
@@ -2587,8 +2611,8 @@ static void find_args (c2m_ctx_t c2m_ctx, macro_call_t mc) { /* we have just rea
   VARR (token_t) * arg, *temp_arr;
 
   m = mc->macro;
-  VARR_CREATE (token_arr_t, args, 16);
-  VARR_CREATE (token_t, arg, 16);
+  VARR_CREATE (token_arr_t, args, alloc, 16);
+  VARR_CREATE (token_t, arg, alloc, 16);
   params_len = VARR_LENGTH (token_t, m->params);
   va_p = params_len == 1 && VARR_GET (token_t, m->params, 0)->code == T_DOTS;
 #ifdef C2MIR_PREPRO_DEBUG
@@ -2615,7 +2639,7 @@ static void find_args (c2m_ctx_t c2m_ctx, macro_call_t mc) { /* we have just rea
 #ifdef C2MIR_PREPRO_DEBUG
       fprintf (stderr, "\n#    arg %d:", VARR_LENGTH (token_arr_t, args));
 #endif
-      VARR_CREATE (token_t, arg, 16);
+      VARR_CREATE (token_t, arg, alloc, 16);
       if (VARR_LENGTH (token_arr_t, args) == params_len - 1
           && strcmp (VARR_GET (token_t, m->params, params_len - 1)->repr, "...") == 0)
         va_p = 1;
@@ -2659,7 +2683,7 @@ static void find_args (c2m_ctx_t c2m_ctx, macro_call_t mc) { /* we have just rea
     error (c2m_ctx, t->pos, "too many args for call of macro %s", m->id->repr);
   } else if (VARR_LENGTH (token_arr_t, args) < params_len) {
     for (; VARR_LENGTH (token_arr_t, args) < params_len;) {
-      VARR_CREATE (token_t, arg, 16);
+      VARR_CREATE (token_t, arg, alloc, 16);
       VARR_PUSH (token_arr_t, args, arg);
     }
     error (c2m_ctx, t->pos, "not enough args for call of macro %s", m->id->repr);
@@ -2992,6 +3016,7 @@ static const char *get_header_name (c2m_ctx_t c2m_ctx, VARR (token_t) * buffer, 
 }
 
 static void process_directive (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   token_t t, t1;
   int true_p;
@@ -3009,7 +3034,7 @@ static void process_directive (c2m_ctx_t c2m_ctx) {
     skip_nl (c2m_ctx, NULL, NULL);
     return;
   }
-  VARR_CREATE (token_t, temp_buffer, 64);
+  VARR_CREATE (token_t, temp_buffer, alloc, 64);
   if (strcmp (t->repr, "ifdef") == 0 || strcmp (t->repr, "ifndef") == 0) {
     t1 = t;
     if (VARR_LENGTH (ifstate_t, ifs) != 0 && VARR_LAST (ifstate_t, ifs)->skip_p) {
@@ -3350,6 +3375,7 @@ static void replace_defined (c2m_ctx_t c2m_ctx, VARR (token_t) * expr_buffer) {
 static struct val eval (c2m_ctx_t c2m_ctx, node_t tree);
 
 static struct val eval_expr (c2m_ctx_t c2m_ctx, VARR (token_t) * expr_buffer, token_t if_token) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   size_t i, j;
   token_t t, ppt;
@@ -3368,7 +3394,7 @@ static struct val eval_expr (c2m_ctx_t c2m_ctx, VARR (token_t) * expr_buffer, to
   replace_defined (c2m_ctx, output_buffer);
   no_out_p = FALSE;
   reverse_move_tokens (expr_buffer, output_buffer);
-  VARR_CREATE (token_t, temp_buffer, VARR_LENGTH (token_t, expr_buffer));
+  VARR_CREATE (token_t, temp_buffer, alloc, VARR_LENGTH (token_t, expr_buffer));
   for (i = j = 0; i < VARR_LENGTH (token_t, expr_buffer); i++) {
     int change_p = TRUE;
 
@@ -3551,6 +3577,7 @@ static struct val eval (c2m_ctx_t c2m_ctx, node_t tree) {
 }
 
 static macro_call_t try_param_macro_call (c2m_ctx_t c2m_ctx, macro_t m, token_t macro_id) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   macro_call_t mc;
   token_t t1 = get_next_pptoken (c2m_ctx), t2 = NULL;
@@ -3569,7 +3596,7 @@ static macro_call_t try_param_macro_call (c2m_ctx_t c2m_ctx, macro_t m, token_t 
     out_token (c2m_ctx, macro_id);
     return NULL;
   }
-  mc = new_macro_call (m, macro_id->pos);
+  mc = new_macro_call (alloc, m, macro_id->pos);
   find_args (c2m_ctx, mc);
   VARR_PUSH (macro_call_t, macro_call_stack, mc);
   return mc;
@@ -3586,6 +3613,7 @@ static macro_call_t try_param_macro_call (c2m_ctx_t c2m_ctx, macro_t m, token_t 
 #define PROP_NE "__builtin_prop_ne"
 
 static void processing (c2m_ctx_t c2m_ctx, int ignore_directive_p) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   token_t t;
   struct macro macro_struct;
@@ -3747,7 +3775,7 @@ static void processing (c2m_ctx_t c2m_ctx, int ignore_directive_p) {
 #ifdef C2MIR_PREPRO_DEBUG
       fprintf (stderr, "# push back <EOR>\n");
 #endif
-      mc = new_macro_call (m, t->pos);
+      mc = new_macro_call (alloc, m, t->pos);
       add_tokens (mc->repl_buffer, m->replacement);
       copy_and_push_back (c2m_ctx, do_concat (c2m_ctx, mc->repl_buffer), mc->pos);
       m->ignore_p = TRUE;
@@ -3970,9 +3998,10 @@ static htab_hash_t tpname_hash (tpname_t tpname, void *arg MIR_UNUSED) {
 }
 
 static void tpname_init (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   parse_ctx_t parse_ctx = c2m_ctx->parse_ctx;
 
-  HTAB_CREATE (tpname_t, tpname_tab, 1000, tpname_hash, tpname_eq, NULL);
+  HTAB_CREATE (tpname_t, tpname_tab, alloc, 1000, tpname_hash, tpname_eq, NULL);
 }
 
 static int tpname_find (c2m_ctx_t c2m_ctx, node_t id, node_t scope, tpname_t *res) {
@@ -5404,6 +5433,7 @@ static void kw_add (c2m_ctx_t c2m_ctx, const char *name, token_code_t tc, size_t
 }
 
 static void parse_init (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   parse_ctx_t parse_ctx;
 
   c2m_ctx->parse_ctx = parse_ctx = c2mir_calloc (c2m_ctx, sizeof (struct parse_ctx));
@@ -5412,8 +5442,8 @@ static void parse_init (c2m_ctx_t c2m_ctx) {
   record_level = 0;
   curr_uid = 0;
   init_streams (c2m_ctx);
-  VARR_CREATE (token_t, recorded_tokens, 32);
-  VARR_CREATE (token_t, buffered_tokens, 32);
+  VARR_CREATE (token_t, recorded_tokens, alloc, 32);
+  VARR_CREATE (token_t, buffered_tokens, alloc, 32);
   pre_init (c2m_ctx);
   kw_add (c2m_ctx, "_Bool", T_BOOL, 0);
   kw_add (c2m_ctx, "_Complex", T_COMPLEX, 0);
@@ -5588,7 +5618,8 @@ static htab_hash_t symbol_hash (symbol_t s, void *arg MIR_UNUSED) {
 static void symbol_clear (symbol_t sym, void *arg MIR_UNUSED) { VARR_DESTROY (node_t, sym.defs); }
 
 static void symbol_init (c2m_ctx_t c2m_ctx) {
-  HTAB_CREATE_WITH_FREE_FUNC (symbol_t, symbol_tab, 5000, symbol_hash, symbol_eq, symbol_clear,
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
+  HTAB_CREATE_WITH_FREE_FUNC (symbol_t, symbol_tab, alloc, 5000, symbol_hash, symbol_eq, symbol_clear,
                               NULL);
 }
 
@@ -5607,6 +5638,7 @@ static int symbol_find (c2m_ctx_t c2m_ctx, enum symbol_mode mode, node_t id, nod
 
 static void symbol_insert (c2m_ctx_t c2m_ctx, enum symbol_mode mode, node_t id, node_t scope,
                            node_t def_node, node_t aux_node) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   symbol_t el, symbol;
 
   symbol.mode = mode;
@@ -5614,16 +5646,17 @@ static void symbol_insert (c2m_ctx_t c2m_ctx, enum symbol_mode mode, node_t id, 
   symbol.scope = scope;
   symbol.def_node = def_node;
   symbol.aux_node = aux_node;
-  VARR_CREATE (node_t, symbol.defs, 4);
+  VARR_CREATE (node_t, symbol.defs, alloc, 4);
   VARR_PUSH (node_t, symbol.defs, def_node);
   HTAB_DO (symbol_t, symbol_tab, symbol, HTAB_INSERT, el);
 }
 
 static void symbol_def_replace (c2m_ctx_t c2m_ctx, symbol_t symbol, node_t def_node) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   symbol_t el;
   VARR (node_t) * defs;
 
-  VARR_CREATE (node_t, defs, 4);
+  VARR_CREATE (node_t, defs, alloc, 4);
   for (size_t i = 0; i < VARR_LENGTH (node_t, symbol.defs); i++)
     VARR_PUSH (node_t, defs, VARR_GET (node_t, symbol.defs, i));
   symbol.defs = defs;
@@ -10031,20 +10064,21 @@ static void do_context (c2m_ctx_t c2m_ctx, node_t r) {
 }
 
 static void context_init (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   check_ctx_t check_ctx;
 
   c2m_ctx->check_ctx = check_ctx = c2mir_calloc (c2m_ctx, sizeof (struct check_ctx));
   n_i1_node = new_i_node (c2m_ctx, 1, no_pos);
-  VARR_CREATE (node_t, context_stack, 64);
+  VARR_CREATE (node_t, context_stack, alloc, 64);
   check (c2m_ctx, n_i1_node, NULL);
   func_block_scope = curr_scope = NULL;
-  VARR_CREATE (node_t, label_uses, 0);
+  VARR_CREATE (node_t, label_uses, alloc, 0);
   symbol_init (c2m_ctx);
   in_params_p = FALSE;
   curr_unnamed_anon_struct_union_member = NULL;
-  HTAB_CREATE (case_t, case_tab, 100, case_hash, case_eq, NULL);
-  VARR_CREATE (decl_t, func_decls_for_allocation, 1024);
-  VARR_CREATE (node_t, possible_incomplete_decls, 512);
+  HTAB_CREATE (case_t, case_tab, alloc, 100, case_hash, case_eq, NULL);
+  VARR_CREATE (decl_t, func_decls_for_allocation, alloc, 1024);
+  VARR_CREATE (node_t, possible_incomplete_decls, alloc, 512);
 }
 
 static void context_finish (c2m_ctx_t c2m_ctx) {
@@ -10179,10 +10213,11 @@ static int reg_var_eq (reg_var_t r1, reg_var_t r2, void *arg MIR_UNUSED) {
 }
 
 static void init_reg_vars (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   gen_ctx_t gen_ctx = c2m_ctx->gen_ctx;
 
   reg_free_mark = 0;
-  HTAB_CREATE (reg_var_t, reg_var_tab, 128, reg_var_hash, reg_var_eq, NULL);
+  HTAB_CREATE (reg_var_t, reg_var_tab, alloc, 128, reg_var_hash, reg_var_eq, NULL);
 }
 
 static void finish_curr_func_reg_vars (c2m_ctx_t c2m_ctx) {
@@ -13503,13 +13538,14 @@ static MIR_item_t get_mir_proto (c2m_ctx_t c2m_ctx, int vararg_p) {
 }
 
 static void gen_mir_protos (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   gen_ctx_t gen_ctx = c2m_ctx->gen_ctx;
   node_t call, func, op1;
   struct type *type;
   struct func_type *func_type;
 
   curr_mir_proto_num = 0;
-  HTAB_CREATE (MIR_item_t, proto_tab, 512, proto_hash, proto_eq, NULL);
+  HTAB_CREATE (MIR_item_t, proto_tab, alloc, 512, proto_hash, proto_eq, NULL);
   for (size_t i = 0; i < VARR_LENGTH (node_t, call_nodes); i++) {
     call = VARR_GET (node_t, call_nodes, i);
     assert (call->code == N_CALL);
@@ -13548,6 +13584,7 @@ static void gen_finish (c2m_ctx_t c2m_ctx) {
 }
 
 static void gen_mir (c2m_ctx_t c2m_ctx, node_t r) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   gen_ctx_t gen_ctx;
   MIR_context_t ctx = c2m_ctx->ctx;
 
@@ -13556,15 +13593,15 @@ static void gen_mir (c2m_ctx_t c2m_ctx, node_t r) {
   one_op = new_op (NULL, MIR_new_int_op (ctx, 1));
   minus_one_op = new_op (NULL, MIR_new_int_op (ctx, -1));
   init_reg_vars (c2m_ctx);
-  VARR_CREATE (MIR_var_t, proto_info.arg_vars, 32);
-  VARR_CREATE (MIR_type_t, proto_info.ret_types, 16);
+  VARR_CREATE (MIR_var_t, proto_info.arg_vars, alloc, 32);
+  VARR_CREATE (MIR_type_t, proto_info.ret_types, alloc, 16);
   gen_mir_protos (c2m_ctx);
-  VARR_CREATE (MIR_op_t, call_ops, 32);
-  VARR_CREATE (MIR_op_t, ret_ops, 8);
-  VARR_CREATE (MIR_op_t, switch_ops, 128);
-  VARR_CREATE (case_t, switch_cases, 64);
-  VARR_CREATE (init_el_t, init_els, 128);
-  VARR_CREATE (node_t, node_stack, 8);
+  VARR_CREATE (MIR_op_t, call_ops, alloc, 32);
+  VARR_CREATE (MIR_op_t, ret_ops, alloc, 8);
+  VARR_CREATE (MIR_op_t, switch_ops, alloc, 128);
+  VARR_CREATE (case_t, switch_cases, alloc, 64);
+  VARR_CREATE (init_el_t, init_els, alloc, 128);
+  VARR_CREATE (node_t, node_stack, alloc, 8);
   memset_proto = memset_item = memcpy_proto = memcpy_item = NULL;
   top_gen (c2m_ctx, r, NULL, NULL, NULL);
   gen_finish (c2m_ctx);
@@ -13983,10 +14020,11 @@ static void print_node (c2m_ctx_t c2m_ctx, FILE *f, node_t n, int indent, int at
 }
 
 static void init_include_dirs (c2m_ctx_t c2m_ctx) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   int MIR_UNUSED added_p = FALSE;
 
-  VARR_CREATE (char_ptr_t, headers, 0);
-  VARR_CREATE (char_ptr_t, system_headers, 0);
+  VARR_CREATE (char_ptr_t, headers, alloc, 0);
+  VARR_CREATE (char_ptr_t, system_headers, alloc, 0);
   for (size_t i = 0; i < c2m_options->include_dirs_num; i++) {
     VARR_PUSH (char_ptr_t, headers, c2m_options->include_dirs[i]);
     VARR_PUSH (char_ptr_t, system_headers, c2m_options->include_dirs[i]);
@@ -14045,6 +14083,7 @@ static int check_id_p (c2m_ctx_t c2m_ctx, const char *str) {
 }
 
 static void define_cmd_macro (c2m_ctx_t c2m_ctx, const char *name, const char *def) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   pre_ctx_t pre_ctx = c2m_ctx->pre_ctx;
   pos_t pos;
   token_t t, id;
@@ -14055,7 +14094,7 @@ static void define_cmd_macro (c2m_ctx_t c2m_ctx, const char *name, const char *d
   pos.fname = COMMAND_LINE_SOURCE_NAME;
   pos.lno = 1;
   pos.ln_pos = 0;
-  VARR_CREATE (token_t, repl, 16);
+  VARR_CREATE (token_t, repl, alloc, 16);
   id = new_id_token (c2m_ctx, pos, name);
   VARR_TRUNC (char, temp_string, 0);
   for (; *def != '\0'; def++) VARR_PUSH (char, temp_string, *def);
@@ -14104,20 +14143,21 @@ static void process_macro_commands (c2m_ctx_t c2m_ctx) {
 
 static void compile_init (c2m_ctx_t c2m_ctx, struct c2mir_options *ops, int (*getc_func) (void *),
                           void *getc_data) {
+  MIR_alloc_t alloc = c2m_alloc (c2m_ctx);
   c2m_options = ops;
   n_errors = n_warnings = 0;
   c_getc = getc_func;
   c_getc_data = getc_data;
-  VARR_CREATE (char, symbol_text, 128);
-  VARR_CREATE (char, temp_string, 128);
-  VARR_CREATE (pos_t, node_positions, 128);
+  VARR_CREATE (char, symbol_text, alloc, 128);
+  VARR_CREATE (char, temp_string, alloc, 128);
+  VARR_CREATE (pos_t, node_positions, alloc, 128);
   parse_init (c2m_ctx);
   context_init (c2m_ctx);
   init_include_dirs (c2m_ctx);
   process_macro_commands (c2m_ctx);
-  VARR_CREATE (node_t, call_nodes, 128); /* used in context and gen */
-  VARR_CREATE (node_t, containing_anon_members, 8);
-  VARR_CREATE (init_object_t, init_object_path, 8);
+  VARR_CREATE (node_t, call_nodes, alloc, 128); /* used in context and gen */
+  VARR_CREATE (node_t, containing_anon_members, alloc, 8);
+  VARR_CREATE (init_object_t, init_object_path, alloc, 8);
 }
 
 static void compile_finish (c2m_ctx_t c2m_ctx) {

--- a/mir-aarch64.c
+++ b/mir-aarch64.c
@@ -334,7 +334,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   mir_assert (__SIZEOF_LONG_DOUBLE__ == 8 || __SIZEOF_LONG_DOUBLE__ == 16);
   for (size_t i = 0; i < nargs; i++) { /* calculate offset for blk params */
 #if defined(__APPLE__)                 /* all varargs are passed on stack */
@@ -516,7 +516,7 @@ void *_MIR_get_interp_shim (MIR_context_t ctx, MIR_item_t func_item, void *handl
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
 #if defined(__APPLE__)
   int stack_arg_sp_offset, sp_offset, scale;
   uint32_t qwords, sp = 31;
@@ -683,7 +683,7 @@ void *_MIR_get_wrapper (MIR_context_t ctx, MIR_item_t called_func, void *hook_ad
   size_t len = 5 * 4; /* initial len */
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   for (;;) { /* dealing with moving code to another page as the immediate call is pc relative */
     curr_addr = base_addr = _MIR_get_new_code_addr (ctx, len);
     if (curr_addr == NULL) break;
@@ -736,7 +736,7 @@ void *_MIR_get_wrapper_end (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   size_t len;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, wrap_end, sizeof (wrap_end));
   len = VARR_LENGTH (uint8_t, code);
   res_code = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), len);
@@ -752,7 +752,7 @@ void *_MIR_get_bb_thunk (MIR_context_t ctx, void *bb_version, void *handler) {
   size_t offset;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 64);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 64);
   offset = gen_mov_addr (code, 9, bb_version); /* x9 = bb_version */
   push_insns (code, pat, sizeof (pat));
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
@@ -818,7 +818,7 @@ void *_MIR_get_bb_wrapper (MIR_context_t ctx, void *data, void *hook_address) {
   void *res;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, &save_fplr, sizeof (save_fplr));
   push_insns (code, save_insns, sizeof (save_insns));
   push_insns (code, save_insns2, sizeof (save_insns2));

--- a/mir-alloc-default.c
+++ b/mir-alloc-default.c
@@ -1,0 +1,36 @@
+/* This file is a part of MIR project.
+   Copyright (C) 2018-2024 Vladimir Makarov <vmakarov.gcc@gmail.com>.
+*/
+
+#include <stdlib.h>
+#include "mir-alloc.h"
+
+#ifdef __GNUC__
+#define ALLOC_UNUSED __attribute__ ((unused))
+#else
+#define ALLOC_UNUSED
+#endif
+
+static void *default_malloc (size_t size, void *user_data ALLOC_UNUSED) {
+  return malloc (size);
+}
+
+static void *default_calloc (size_t num, size_t size, void *user_data ALLOC_UNUSED) {
+  return calloc (num, size);
+}
+
+static void *default_realloc (void *ptr, size_t old_size ALLOC_UNUSED, size_t new_size, void *user_data ALLOC_UNUSED) {
+  return realloc (ptr, new_size);
+}
+
+static void default_free (void *ptr, void *user_data ALLOC_UNUSED) {
+  free (ptr);
+}
+
+static struct MIR_alloc default_alloc = {
+  .malloc = default_malloc,
+  .calloc = default_calloc,
+  .realloc = default_realloc,
+  .free = default_free,
+  .user_data = NULL
+};

--- a/mir-alloc.h
+++ b/mir-alloc.h
@@ -1,0 +1,46 @@
+/* This file is a part of MIR project.
+   Copyright (C) 2018-2024 Vladimir Makarov <vmakarov.gcc@gmail.com>.
+*/
+
+#ifndef MIR_ALLOC_H
+#define MIR_ALLOC_H
+
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct MIR_alloc {
+  void *(*malloc) (size_t, void *);
+  void *(*calloc) (size_t, size_t, void *);
+  void *(*realloc) (void *, size_t, size_t, void *);
+  void (*free) (void *, void *);
+  void *user_data;
+} *MIR_alloc_t;
+
+static inline void *MIR_malloc (MIR_alloc_t alloc, size_t size) {
+  assert (alloc != NULL);
+  return alloc->malloc (size, alloc->user_data);
+}
+
+static inline void *MIR_calloc (MIR_alloc_t alloc, size_t num, size_t size) {
+  assert (alloc != NULL);
+  return alloc->calloc (num, size, alloc->user_data);
+}
+
+static inline void *MIR_realloc (MIR_alloc_t alloc, void *ptr, size_t old_size, size_t new_size) {
+  assert (alloc != NULL);
+  return alloc->realloc (ptr, old_size, new_size, alloc->user_data);
+}
+
+static inline void MIR_free (MIR_alloc_t alloc, void *ptr) {
+  assert (alloc != NULL);
+  alloc->free (ptr, alloc->user_data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef MIR_ALLOC_H */

--- a/mir-bitmap.h
+++ b/mir-bitmap.h
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <stdint.h>
 #include <limits.h>
+#include "mir-alloc.h"
 #include "mir-varr.h"
 
 #define FALSE 0
@@ -43,14 +44,14 @@ DEF_VARR (bitmap_el_t);
 typedef VARR (bitmap_el_t) * bitmap_t;
 typedef const VARR (bitmap_el_t) * const_bitmap_t;
 
-static inline bitmap_t bitmap_create2 (size_t init_bits_num) {
+static inline bitmap_t bitmap_create2 (MIR_alloc_t alloc, size_t init_bits_num) {
   bitmap_t bm;
 
-  VARR_CREATE (bitmap_el_t, bm, (init_bits_num + BITMAP_WORD_BITS - 1) / BITMAP_WORD_BITS);
+  VARR_CREATE (bitmap_el_t, bm, alloc, (init_bits_num + BITMAP_WORD_BITS - 1) / BITMAP_WORD_BITS);
   return bm;
 }
 
-static inline bitmap_t bitmap_create (void) { return bitmap_create2 (0); }
+static inline bitmap_t bitmap_create (MIR_alloc_t alloc) { return bitmap_create2 (alloc, 0); }
 
 static inline void bitmap_destroy (bitmap_t bm) { VARR_DESTROY (bitmap_el_t, bm); }
 

--- a/mir-code-alloc-default.c
+++ b/mir-code-alloc-default.c
@@ -1,0 +1,90 @@
+/* This file is a part of MIR project.
+   Copyright (C) 2018-2024 Vladimir Makarov <vmakarov.gcc@gmail.com>.
+*/
+
+#include <stdlib.h>
+#include "mir-code-alloc.h"
+
+#ifdef __GNUC__
+#define CODE_ALLOC_UNUSED __attribute__ ((unused))
+#else
+#define CODE_ALLOC_UNUSED
+#endif
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <unistd.h>
+
+static inline int get_native_mem_protect_flags (MIR_mem_protect_t prot) {
+  return prot == PROT_WRITE_EXEC ?
+#if defined(__riscv)
+    (PROT_WRITE | PROT_READ | PROT_EXEC)
+#else
+    (PROT_WRITE | PROT_EXEC)
+#endif
+    : (PROT_READ | PROT_EXEC);
+}
+
+#if defined(__APPLE__) && defined(__aarch64__)
+#include <libkern/OSCacheControl.h>
+#include <pthread.h>
+#endif
+
+static int default_mem_protect (void *addr, size_t len, MIR_mem_protect_t prot, void *user_data CODE_ALLOC_UNUSED) {
+  int native_prot = get_native_mem_protect_flags (prot);
+#if !defined(__APPLE__) || !defined(__aarch64__)
+  return mprotect (addr, len, native_prot);
+#else
+  if ((native_prot & PROT_WRITE) && pthread_jit_write_protect_supported_np ())
+    pthread_jit_write_protect_np (FALSE);
+  if (native_prot & PROT_READ) {
+    if (pthread_jit_write_protect_supported_np ()) pthread_jit_write_protect_np (TRUE);
+    sys_icache_invalidate (addr, len);
+  } else if (0) {
+    if (mprotect (addr, len, native_prot) != 0) {
+      perror ("mem_protect");
+      fprintf (stderr, "good bye!\n");
+      exit (1);
+    }
+  }
+  return 0;
+#endif
+}
+
+static int default_mem_unmap (void *addr, size_t len, void *user_data CODE_ALLOC_UNUSED) {
+  return munmap (addr, len);
+}
+
+static void *default_mem_map (size_t len, void *user_data CODE_ALLOC_UNUSED) {
+#if defined(__APPLE__) && defined(__aarch64__)
+  return mmap (NULL, len, PROT_EXEC | PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT,
+               -1, 0);
+#else
+  return mmap (NULL, len, PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
+}
+#else
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+static int default_mem_protect (void *addr, size_t len, MIR_mem_protect_t prot, void *user_data CODE_ALLOC_UNUSED) {
+  int native_prod = prot == PROT_WRITE_EXEC ? PAGE_EXECUTE_READWRITE : PAGE_EXECUTE_READ;
+  DWORD old_prot = 0;
+  return VirtualProtect (addr, len, native_prod, &old_prot) ? 0 : -1;
+}
+
+static int default_mem_unmap (void *addr, size_t len, void *user_data CODE_ALLOC_UNUSED) {
+  return VirtualFree (addr, len, MEM_RELEASE) ? 0 : -1;
+}
+
+static void *default_mem_map (size_t len, void *user_data CODE_ALLOC_UNUSED) {
+  return VirtualAlloc (NULL, len, MEM_COMMIT, PAGE_EXECUTE);
+}
+#endif
+
+static struct MIR_code_alloc default_code_alloc = {
+  .mem_map = default_mem_map,
+  .mem_unmap = default_mem_unmap,
+  .mem_protect = default_mem_protect,
+  .user_data = NULL
+};

--- a/mir-code-alloc.h
+++ b/mir-code-alloc.h
@@ -1,0 +1,44 @@
+/* This file is a part of MIR project.
+   Copyright (C) 2018-2024 Vladimir Makarov <vmakarov.gcc@gmail.com>.
+*/
+
+#ifndef MIR_CODE_ALLOC_H
+#define MIR_CODE_ALLOC_H
+
+#include <assert.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAP_FAILED NULL
+
+typedef enum MIR_mem_protect {
+  PROT_WRITE_EXEC,
+  PROT_READ_EXEC
+} MIR_mem_protect_t;
+
+typedef struct MIR_code_alloc {
+  void *(*mem_map) (size_t, void *);
+  int (*mem_unmap) (void *, size_t, void *);
+  int (*mem_protect) (void *, size_t, MIR_mem_protect_t, void *);
+  void *user_data;
+} *MIR_code_alloc_t;
+
+static inline void *MIR_mem_map (MIR_code_alloc_t code_alloc, size_t len) {
+  return code_alloc->mem_map (len, code_alloc->user_data);
+}
+
+static inline int MIR_mem_unmap (MIR_code_alloc_t code_alloc, void *addr, size_t len) {
+  return code_alloc->mem_unmap (addr, len, code_alloc->user_data);
+}
+
+static inline int MIR_mem_protect (MIR_code_alloc_t code_alloc, void *addr, size_t len, MIR_mem_protect_t prot) {
+  return code_alloc->mem_protect (addr, len, prot, code_alloc->user_data);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef MIR_CODE_ALLOC_H */

--- a/mir-gen-aarch64.c
+++ b/mir-gen-aarch64.c
@@ -1808,15 +1808,16 @@ static int pattern_index_cmp (const void *a1, const void *a2) {
 }
 
 static void patterns_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   int i, ind, n = sizeof (patterns) / sizeof (struct pattern);
   MIR_insn_code_t prev_code, code;
   insn_pattern_info_t *info_addr;
   insn_pattern_info_t pinfo = {0, 0};
 
-  VARR_CREATE (int, pattern_indexes, 0);
+  VARR_CREATE (int, pattern_indexes, alloc, 0);
   for (i = 0; i < n; i++) VARR_PUSH (int, pattern_indexes, i);
   qsort (VARR_ADDR (int, pattern_indexes), n, sizeof (int), pattern_index_cmp);
-  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, 0);
+  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, alloc, 0);
   for (i = 0; i < ARM_INSN_BOUND; i++) VARR_PUSH (insn_pattern_info_t, insn_pattern_info, pinfo);
   info_addr = VARR_ADDR (insn_pattern_info_t, insn_pattern_info);
   for (prev_code = ARM_INSN_BOUND, i = 0; i < n; i++) {
@@ -2651,25 +2652,27 @@ static void target_redirect_bb_origin_branch (gen_ctx_t gen_ctx, target_bb_versi
 }
 
 static void target_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
 
   gen_ctx->target_ctx = gen_malloc (gen_ctx, sizeof (struct target_ctx));
-  VARR_CREATE (uint8_t, result_code, 0);
-  VARR_CREATE (label_ref_t, label_refs, 0);
-  VARR_CREATE (uint64_t, abs_address_locs, 0);
-  VARR_CREATE (MIR_code_reloc_t, relocs, 0);
+  VARR_CREATE (uint8_t, result_code, alloc, 0);
+  VARR_CREATE (label_ref_t, label_refs, alloc, 0);
+  VARR_CREATE (uint64_t, abs_address_locs, alloc, 0);
+  VARR_CREATE (MIR_code_reloc_t, relocs, alloc, 0);
   patterns_init (gen_ctx);
   temp_jump = MIR_new_insn (ctx, MIR_JMP, MIR_new_label_op (ctx, NULL));
   temp_jump_replacement = find_insn_pattern_replacement (gen_ctx, temp_jump);
 }
 
 static void target_finish (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   patterns_finish (gen_ctx);
   _MIR_free_insn (gen_ctx->ctx, temp_jump);
   VARR_DESTROY (uint8_t, result_code);
   VARR_DESTROY (label_ref_t, label_refs);
   VARR_DESTROY (uint64_t, abs_address_locs);
   VARR_DESTROY (MIR_code_reloc_t, relocs);
-  free (gen_ctx->target_ctx);
+  MIR_free (alloc, gen_ctx->target_ctx);
   gen_ctx->target_ctx = NULL;
 }

--- a/mir-gen-ppc64.c
+++ b/mir-gen-ppc64.c
@@ -1478,15 +1478,16 @@ static int pattern_index_cmp (const void *a1, const void *a2) {
 }
 
 static void patterns_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   int i, ind, n = sizeof (patterns) / sizeof (struct pattern);
   MIR_insn_code_t prev_code, code;
   insn_pattern_info_t *info_addr;
   insn_pattern_info_t pinfo = {0, 0};
 
-  VARR_CREATE (int, pattern_indexes, 0);
+  VARR_CREATE (int, pattern_indexes, alloc, 0);
   for (i = 0; i < n; i++) VARR_PUSH (int, pattern_indexes, i);
   qsort (VARR_ADDR (int, pattern_indexes), n, sizeof (int), pattern_index_cmp);
-  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, 0);
+  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, alloc, 0);
   for (i = 0; i < MIR_INSN_BOUND; i++) VARR_PUSH (insn_pattern_info_t, insn_pattern_info, pinfo);
   info_addr = VARR_ADDR (insn_pattern_info_t, insn_pattern_info);
   for (prev_code = MIR_INSN_BOUND, i = 0; i < n; i++) {
@@ -2621,25 +2622,27 @@ static void target_redirect_bb_origin_branch (gen_ctx_t gen_ctx, target_bb_versi
 }
 
 static void target_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
 
   gen_ctx->target_ctx = gen_malloc (gen_ctx, sizeof (struct target_ctx));
-  VARR_CREATE (uint8_t, result_code, 0);
-  VARR_CREATE (label_ref_t, label_refs, 0);
-  VARR_CREATE (uint64_t, abs_address_locs, 0);
-  VARR_CREATE (MIR_code_reloc_t, relocs, 0);
+  VARR_CREATE (uint8_t, result_code, alloc, 0);
+  VARR_CREATE (label_ref_t, label_refs, alloc, 0);
+  VARR_CREATE (uint64_t, abs_address_locs, alloc, 0);
+  VARR_CREATE (MIR_code_reloc_t, relocs, alloc, 0);
   patterns_init (gen_ctx);
   temp_jump = MIR_new_insn (ctx, MIR_JMP, MIR_new_label_op (ctx, NULL));
   temp_jump_replacement = find_insn_pattern_replacement (gen_ctx, temp_jump, FALSE);
 }
 
 static void target_finish (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   patterns_finish (gen_ctx);
   _MIR_free_insn (gen_ctx->ctx, temp_jump);
   VARR_DESTROY (uint8_t, result_code);
   VARR_DESTROY (label_ref_t, label_refs);
   VARR_DESTROY (uint64_t, abs_address_locs);
   VARR_DESTROY (MIR_code_reloc_t, relocs);
-  free (gen_ctx->target_ctx);
+  MIR_free (alloc, gen_ctx->target_ctx);
   gen_ctx->target_ctx = NULL;
 }

--- a/mir-gen-riscv64.c
+++ b/mir-gen-riscv64.c
@@ -1806,15 +1806,16 @@ static int pattern_index_cmp (const void *a1, const void *a2) {
 }
 
 static void patterns_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   int i, ind, n = sizeof (patterns) / sizeof (struct pattern);
   MIR_insn_code_t prev_code, code;
   insn_pattern_info_t *info_addr;
   insn_pattern_info_t pinfo = {0, 0};
 
-  VARR_CREATE (int, pattern_indexes, 0);
+  VARR_CREATE (int, pattern_indexes, alloc, 0);
   for (i = 0; i < n; i++) VARR_PUSH (int, pattern_indexes, i);
   qsort (VARR_ADDR (int, pattern_indexes), n, sizeof (int), pattern_index_cmp);
-  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, 0);
+  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, alloc, 0);
   for (i = 0; i < MIR_INSN_BOUND; i++) VARR_PUSH (insn_pattern_info_t, insn_pattern_info, pinfo);
   info_addr = VARR_ADDR (insn_pattern_info_t, insn_pattern_info);
   for (prev_code = MIR_INSN_BOUND, i = 0; i < n; i++) {
@@ -2967,14 +2968,15 @@ static void target_redirect_bb_origin_branch (gen_ctx_t gen_ctx, target_bb_versi
 }
 
 static void target_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
   check_hard_reg_alloc_order ();
   gen_ctx->target_ctx = gen_malloc (gen_ctx, sizeof (struct target_ctx));
-  VARR_CREATE (uint8_t, result_code, 0);
-  VARR_CREATE (label_ref_t, label_refs, 0);
-  VARR_CREATE (const_ref_t, const_refs, 0);
-  VARR_CREATE (uint64_t, abs_address_locs, 0);
-  VARR_CREATE (MIR_code_reloc_t, relocs, 0);
+  VARR_CREATE (uint8_t, result_code, alloc, 0);
+  VARR_CREATE (label_ref_t, label_refs, alloc, 0);
+  VARR_CREATE (const_ref_t, const_refs, alloc, 0);
+  VARR_CREATE (uint64_t, abs_address_locs, alloc, 0);
+  VARR_CREATE (MIR_code_reloc_t, relocs, alloc, 0);
   MIR_type_t res = MIR_T_I64;
   MIR_var_t args1[] = {{MIR_T_F, "src", 0}};
   MIR_var_t args2[] = {{MIR_T_D, "src", 0}};
@@ -2986,6 +2988,7 @@ static void target_init (gen_ctx_t gen_ctx) {
 }
 
 static void target_finish (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   patterns_finish (gen_ctx);
   _MIR_free_insn (gen_ctx->ctx, temp_jump);
   VARR_DESTROY (uint8_t, result_code);
@@ -2993,6 +2996,6 @@ static void target_finish (gen_ctx_t gen_ctx) {
   VARR_DESTROY (const_ref_t, const_refs);
   VARR_DESTROY (uint64_t, abs_address_locs);
   VARR_DESTROY (MIR_code_reloc_t, relocs);
-  free (gen_ctx->target_ctx);
+  MIR_free (alloc, gen_ctx->target_ctx);
   gen_ctx->target_ctx = NULL;
 }

--- a/mir-gen-s390x.c
+++ b/mir-gen-s390x.c
@@ -1475,15 +1475,16 @@ static int pattern_index_cmp (const void *a1, const void *a2) {
 }
 
 static void patterns_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   int i, ind, n = sizeof (patterns) / sizeof (struct pattern);
   MIR_insn_code_t prev_code, code;
   insn_pattern_info_t *info_addr;
   insn_pattern_info_t pinfo = {0, 0};
 
-  VARR_CREATE (int, pattern_indexes, 0);
+  VARR_CREATE (int, pattern_indexes, alloc, 0);
   for (i = 0; i < n; i++) VARR_PUSH (int, pattern_indexes, i);
   qsort (VARR_ADDR (int, pattern_indexes), n, sizeof (int), pattern_index_cmp);
-  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, 0);
+  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, alloc, 0);
   for (i = 0; i < MIR_INSN_BOUND; i++) VARR_PUSH (insn_pattern_info_t, insn_pattern_info, pinfo);
   info_addr = VARR_ADDR (insn_pattern_info_t, insn_pattern_info);
   for (prev_code = MIR_INSN_BOUND, i = 0; i < n; i++) {
@@ -2403,22 +2404,24 @@ static void target_redirect_bb_origin_branch (gen_ctx_t gen_ctx, target_bb_versi
 }
 
 static void target_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
 
   gen_ctx->target_ctx = gen_malloc (gen_ctx, sizeof (struct target_ctx));
-  VARR_CREATE (uint8_t, result_code, 0);
-  VARR_CREATE (uint64_t, const_pool, 0);
-  VARR_CREATE (const_ref_t, const_refs, 0);
-  VARR_CREATE (label_ref_t, label_refs, 0);
-  VARR_CREATE (uint64_t, abs_address_locs, 0);
-  VARR_CREATE (MIR_code_reloc_t, relocs, 0);
-  VARR_CREATE (uint64_t, ld_addr_regs, 0);
+  VARR_CREATE (uint8_t, result_code, alloc, 0);
+  VARR_CREATE (uint64_t, const_pool, alloc, 0);
+  VARR_CREATE (const_ref_t, const_refs, alloc, 0);
+  VARR_CREATE (label_ref_t, label_refs, alloc, 0);
+  VARR_CREATE (uint64_t, abs_address_locs, alloc, 0);
+  VARR_CREATE (MIR_code_reloc_t, relocs, alloc, 0);
+  VARR_CREATE (uint64_t, ld_addr_regs, alloc, 0);
   patterns_init (gen_ctx);
   temp_jump = MIR_new_insn (ctx, MIR_JMP, MIR_new_label_op (ctx, NULL));
   temp_jump_replacement = find_insn_pattern_replacement (gen_ctx, temp_jump);
 }
 
 static void target_finish (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   patterns_finish (gen_ctx);
   _MIR_free_insn (gen_ctx->ctx, temp_jump);
   VARR_DESTROY (uint8_t, result_code);
@@ -2428,6 +2431,6 @@ static void target_finish (gen_ctx_t gen_ctx) {
   VARR_DESTROY (uint64_t, abs_address_locs);
   VARR_DESTROY (MIR_code_reloc_t, relocs);
   VARR_DESTROY (uint64_t, ld_addr_regs);
-  free (gen_ctx->target_ctx);
+  MIR_free (alloc, gen_ctx->target_ctx);
   gen_ctx->target_ctx = NULL;
 }

--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -1875,12 +1875,13 @@ static int pattern_index_cmp (const void *a1, const void *a2) {
 static int get_max_insn_size (gen_ctx_t gen_ctx, const char *replacement);
 
 static void patterns_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   int i, ind, n = sizeof (patterns) / sizeof (struct pattern);
   MIR_insn_code_t prev_code, code;
   insn_pattern_info_t *info_addr;
   insn_pattern_info_t pinfo = {0, 0};
 
-  VARR_CREATE (int, pattern_indexes, 0);
+  VARR_CREATE (int, pattern_indexes, alloc, 0);
   for (i = 0; i < n; i++) {
     patterns[i].max_insn_size = get_max_insn_size (gen_ctx, patterns[i].replacement);
 #if 0
@@ -1890,7 +1891,7 @@ static void patterns_init (gen_ctx_t gen_ctx) {
     VARR_PUSH (int, pattern_indexes, i);
   }
   qsort (VARR_ADDR (int, pattern_indexes), n, sizeof (int), pattern_index_cmp);
-  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, 0);
+  VARR_CREATE (insn_pattern_info_t, insn_pattern_info, alloc, 0);
   for (i = 0; i < MIR_INSN_BOUND; i++) VARR_PUSH (insn_pattern_info_t, insn_pattern_info, pinfo);
   info_addr = VARR_ADDR (insn_pattern_info_t, insn_pattern_info);
   for (prev_code = MIR_INSN_BOUND, i = 0; i < n; i++) {
@@ -3133,17 +3134,18 @@ static void target_redirect_bb_origin_branch (gen_ctx_t gen_ctx, target_bb_versi
 }
 
 static void target_init (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
 
   gen_ctx->target_ctx = gen_malloc (gen_ctx, sizeof (struct target_ctx));
-  VARR_CREATE (uint8_t, result_code, 0);
-  VARR_CREATE (int, insn_pattern_indexes, 0);
-  VARR_CREATE (uint64_t, const_pool, 0);
-  VARR_CREATE (const_ref_t, const_refs, 0);
-  VARR_CREATE (label_ref_t, label_refs, 0);
-  VARR_CREATE (uint64_t, abs_address_locs, 0);
-  VARR_CREATE (MIR_code_reloc_t, relocs, 0);
-  VARR_CREATE (call_ref_t, gen_ctx->target_ctx->call_refs, 0);
+  VARR_CREATE (uint8_t, result_code, alloc, 0);
+  VARR_CREATE (int, insn_pattern_indexes, alloc, 0);
+  VARR_CREATE (uint64_t, const_pool, alloc, 0);
+  VARR_CREATE (const_ref_t, const_refs, alloc, 0);
+  VARR_CREATE (label_ref_t, label_refs, alloc, 0);
+  VARR_CREATE (uint64_t, abs_address_locs, alloc, 0);
+  VARR_CREATE (MIR_code_reloc_t, relocs, alloc, 0);
+  VARR_CREATE (call_ref_t, gen_ctx->target_ctx->call_refs, alloc, 0);
   MIR_type_t res = MIR_T_D;
   MIR_var_t args[] = {{MIR_T_D, "src", 0}};
   _MIR_register_unspec_insn (gen_ctx->ctx, MOVDQA_CODE, "movdqa", 1, &res, 1, FALSE, args);
@@ -3153,6 +3155,7 @@ static void target_init (gen_ctx_t gen_ctx) {
 }
 
 static void target_finish (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   patterns_finish (gen_ctx);
   _MIR_free_insn (gen_ctx->ctx, temp_jump);
   VARR_DESTROY (uint8_t, result_code);
@@ -3163,6 +3166,6 @@ static void target_finish (gen_ctx_t gen_ctx) {
   VARR_DESTROY (uint64_t, abs_address_locs);
   VARR_DESTROY (MIR_code_reloc_t, relocs);
   VARR_DESTROY (call_ref_t, gen_ctx->target_ctx->call_refs);
-  free (gen_ctx->target_ctx);
+  MIR_free (alloc, gen_ctx->target_ctx);
   gen_ctx->target_ctx = NULL;
 }

--- a/mir-gen.c
+++ b/mir-gen.c
@@ -94,6 +94,8 @@
 #include <inttypes.h>
 
 #include <assert.h>
+#include "mir-code-alloc.h"
+#include "mir-alloc.h"
 
 #define gen_assert(cond) assert (cond)
 
@@ -112,7 +114,9 @@ static void varr_error (const char *message) { util_error (NULL, message); }
 #include "mir-gen.h"
 
 /* Functions used by target dependent code: */
+static MIR_alloc_t gen_alloc (gen_ctx_t gen_ctx);
 static void *gen_malloc (gen_ctx_t gen_ctx, size_t size);
+static void gen_free (gen_ctx_t gen_ctx, void *ptr);
 static MIR_reg_t gen_new_temp_reg (gen_ctx_t gen_ctx, MIR_type_t type, MIR_func_t func);
 static int gen_nested_loop_label_p (gen_ctx_t gen_ctx, MIR_insn_t insn);
 static void set_label_disp (gen_ctx_t gen_ctx, MIR_insn_t insn, size_t disp);
@@ -354,10 +358,20 @@ static void MIR_NO_RETURN util_error (gen_ctx_t gen_ctx, const char *message) {
   (*MIR_get_error_func (gen_ctx->ctx)) (MIR_alloc_error, message);
 }
 
+static MIR_alloc_t gen_alloc (gen_ctx_t gen_ctx) {
+  return MIR_get_alloc (gen_ctx->ctx);
+}
+
 static void *gen_malloc (gen_ctx_t gen_ctx, size_t size) {
-  void *res = malloc (size);
+  MIR_alloc_t alloc = MIR_get_alloc (gen_ctx->ctx);
+  void *res = MIR_malloc (alloc, size);
   if (res == NULL) util_error (gen_ctx, "no memory");
   return res;
+}
+
+static void gen_free (gen_ctx_t gen_ctx, void *ptr) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
+  MIR_free (alloc, ptr);
 }
 
 static void *gen_malloc_and_mark_to_free (gen_ctx_t gen_ctx, size_t size) {
@@ -507,7 +521,7 @@ static void finish_dead_vars (gen_ctx_t gen_ctx) {
 
   while ((dv = DLIST_HEAD (dead_var_t, free_dead_vars)) != NULL) {
     DLIST_REMOVE (dead_var_t, free_dead_vars, dv);
-    free (dv);
+    gen_free (gen_ctx, dv);
   }
 }
 
@@ -586,17 +600,18 @@ static bb_t get_insn_data_bb (MIR_insn_t insn) {
   return insn_data_p (insn) ? ((insn_data_t) insn->data)->bb : (bb_t) insn->data;
 }
 
-static void delete_insn_data (MIR_insn_t insn) {
+static void delete_insn_data (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   insn_data_t insn_data = insn->data;
 
   if (insn_data == NULL || !insn_data_p (insn)) return;
   if (MIR_call_code_p (insn->code) && insn_data->u.call_hard_reg_args != NULL)
     bitmap_destroy (insn_data->u.call_hard_reg_args);
-  free (insn_data);
+  gen_free (gen_ctx, insn_data);
 }
 
 static bb_insn_t create_bb_insn (gen_ctx_t gen_ctx, MIR_insn_t insn, bb_t bb) {
   bb_insn_t bb_insn = gen_malloc (gen_ctx, sizeof (struct bb_insn));
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
 
   insn->data = bb_insn;
   bb_insn->bb = bb;
@@ -609,7 +624,8 @@ static bb_insn_t create_bb_insn (gen_ctx_t gen_ctx, MIR_insn_t insn, bb_t bb) {
   bb_insn->mem_index = 0;
   bb_insn->gvn_val = bb_insn->index;
   DLIST_INIT (dead_var_t, bb_insn->insn_dead_vars);
-  if (MIR_call_code_p (insn->code)) bb_insn->call_hard_reg_args = bitmap_create2 (MAX_HARD_REG + 1);
+  if (MIR_call_code_p (insn->code))
+    bb_insn->call_hard_reg_args = bitmap_create2 (alloc, MAX_HARD_REG + 1);
   bb_insn->label_disp = 0;
   return bb_insn;
 }
@@ -629,7 +645,7 @@ static void delete_bb_insn (gen_ctx_t gen_ctx, bb_insn_t bb_insn) {
   bb_insn->insn->data = NULL;
   clear_bb_insn_dead_vars (gen_ctx, bb_insn);
   if (bb_insn->call_hard_reg_args != NULL) bitmap_destroy (bb_insn->call_hard_reg_args);
-  free (bb_insn);
+  gen_free (gen_ctx, bb_insn);
 }
 
 static bb_t get_insn_bb (gen_ctx_t gen_ctx, MIR_insn_t insn) {
@@ -674,7 +690,7 @@ static void create_new_bb_insns (gen_ctx_t gen_ctx, MIR_insn_t before, MIR_insn_
 
 static void gen_delete_insn (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   if (optimize_level == 0)
-    delete_insn_data (insn);
+    delete_insn_data (gen_ctx, insn);
   else
     delete_bb_insn (gen_ctx, insn->data);
   MIR_remove_insn (gen_ctx->ctx, curr_func_item, insn);
@@ -715,6 +731,7 @@ static void gen_move_insn_before (gen_ctx_t gen_ctx, MIR_insn_t before, MIR_insn
 
 static void MIR_UNUSED setup_call_hard_reg_args (gen_ctx_t gen_ctx, MIR_insn_t call_insn,
                                                  MIR_reg_t hard_reg) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   insn_data_t insn_data;
 
   gen_assert (MIR_call_code_p (call_insn->code) && hard_reg <= MAX_HARD_REG);
@@ -723,7 +740,7 @@ static void MIR_UNUSED setup_call_hard_reg_args (gen_ctx_t gen_ctx, MIR_insn_t c
     return;
   }
   if ((insn_data = call_insn->data)->u.call_hard_reg_args == NULL)
-    insn_data->u.call_hard_reg_args = (void *) bitmap_create2 (MAX_HARD_REG + 1);
+    insn_data->u.call_hard_reg_args = (void *) bitmap_create2 (alloc, MAX_HARD_REG + 1);
   bitmap_set_bit_p (insn_data->u.call_hard_reg_args, hard_reg);
 }
 
@@ -789,6 +806,7 @@ static MIR_reg_t get_temp_hard_reg (MIR_type_t type, int first_p) {
 
 static bb_t create_bb (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   bb_t bb = gen_malloc (gen_ctx, sizeof (struct bb));
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
 
   bb->pre = bb->rpost = bb->bfs = 0;
   bb->loop_node = NULL;
@@ -796,12 +814,12 @@ static bb_t create_bb (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   DLIST_INIT (in_edge_t, bb->in_edges);
   DLIST_INIT (out_edge_t, bb->out_edges);
   bb->call_p = bb->flag = bb->reachable_p = FALSE;
-  bb->in = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  bb->out = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  bb->gen = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  bb->kill = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  bb->dom_in = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  bb->dom_out = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->in = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->out = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->gen = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->kill = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->dom_in = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  bb->dom_out = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
   bb->max_int_pressure = bb->max_fp_pressure = 0;
   if (insn != NULL) {
     if (optimize_level == 0)
@@ -845,10 +863,10 @@ static edge_t create_edge (gen_ctx_t gen_ctx, bb_t src, bb_t dst, int fall_throu
   return e;
 }
 
-static void delete_edge (edge_t e) {
+static void delete_edge (gen_ctx_t gen_ctx, edge_t e) {
   DLIST_REMOVE (out_edge_t, e->src->out_edges, e);
   DLIST_REMOVE (in_edge_t, e->dst->in_edges, e);
-  free (e);
+  gen_free (gen_ctx, e);
 }
 
 static edge_t find_edge (bb_t src, bb_t dst) {
@@ -859,22 +877,23 @@ static edge_t find_edge (bb_t src, bb_t dst) {
 }
 
 static void delete_bb (gen_ctx_t gen_ctx, bb_t bb) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   edge_t e, next_e;
 
   for (e = DLIST_HEAD (out_edge_t, bb->out_edges); e != NULL; e = next_e) {
     next_e = DLIST_NEXT (out_edge_t, e);
-    delete_edge (e);
+    delete_edge (gen_ctx, e);
   }
   for (e = DLIST_HEAD (in_edge_t, bb->in_edges); e != NULL; e = next_e) {
     next_e = DLIST_NEXT (in_edge_t, e);
-    delete_edge (e);
+    delete_edge (gen_ctx, e);
   }
   if (bb->loop_node != NULL) {
     if (bb->loop_node->parent->entry == bb->loop_node) bb->loop_node->parent->entry = NULL;
     DLIST_REMOVE (loop_node_t, bb->loop_node->parent->children, bb->loop_node);
     if (bb->loop_node->u.preheader_loop != NULL)
       bb->loop_node->u.preheader_loop->u.preheader = NULL;
-    free (bb->loop_node);
+    gen_free (gen_ctx, bb->loop_node);
   }
   DLIST_REMOVE (bb_t, curr_cfg->bbs, bb);
   bitmap_destroy (bb->in);
@@ -883,7 +902,7 @@ static void delete_bb (gen_ctx_t gen_ctx, bb_t bb) {
   bitmap_destroy (bb->kill);
   bitmap_destroy (bb->dom_in);
   bitmap_destroy (bb->dom_out);
-  free (bb);
+  gen_free (gen_ctx, bb);
 }
 
 static void print_bb_insn (gen_ctx_t gen_ctx, bb_insn_t bb_insn, int with_notes_p);
@@ -1181,7 +1200,7 @@ static void destroy_loop_tree (gen_ctx_t gen_ctx, loop_node_t root) {
       destroy_loop_tree (gen_ctx, node);
     }
   }
-  free (root);
+  gen_free (gen_ctx, root);
 }
 
 static void update_max_var (gen_ctx_t gen_ctx, MIR_reg_t reg) {
@@ -1550,6 +1569,7 @@ static int label_cmp (const void *l1, const void *l2) {
 }
 
 static void build_func_cfg (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
   MIR_func_t func = curr_func_item->u.func;
   MIR_insn_t insn, insn2, next_insn, ret_insn, use_insn;
@@ -1828,7 +1848,8 @@ static void build_func_cfg (gen_ctx_t gen_ctx) {
   }
   for (MIR_lref_data_t lref = func->first_lref; lref != NULL; lref = lref->next) {
     VARR_PUSH (MIR_insn_t, temp_insns2, lref->label);
-    if (lref->label2 != NULL) VARR_PUSH (MIR_insn_t, temp_insns2, lref->label2);
+    if (lref->label2 != NULL)
+      VARR_PUSH (MIR_insn_t, temp_insns2, lref->label2);
   }
   qsort (VARR_ADDR (MIR_insn_t, temp_insns2), VARR_LENGTH (MIR_insn_t, temp_insns2),
          sizeof (MIR_insn_t), label_cmp);
@@ -1861,8 +1882,8 @@ static void build_func_cfg (gen_ctx_t gen_ctx) {
       create_edge (gen_ctx, bb, exit_bb, FALSE, TRUE);
   }
   enumerate_bbs (gen_ctx);
-  VARR_CREATE (reg_info_t, curr_cfg->reg_info, 128);
-  curr_cfg->call_crossed_regs = bitmap_create2 (curr_cfg->max_var);
+  VARR_CREATE (reg_info_t, curr_cfg->reg_info, alloc, 128);
+  curr_cfg->call_crossed_regs = bitmap_create2 (alloc, curr_cfg->max_var);
 }
 
 static void destroy_func_cfg (gen_ctx_t gen_ctx) {
@@ -1875,7 +1896,7 @@ static void destroy_func_cfg (gen_ctx_t gen_ctx) {
        insn = DLIST_NEXT (MIR_insn_t, insn))
     if (optimize_level == 0) {
       gen_assert (insn->data != NULL);
-      delete_insn_data (insn);
+      delete_insn_data (gen_ctx, insn);
     } else {
       bb_insn = insn->data;
       gen_assert (bb_insn != NULL);
@@ -1887,7 +1908,7 @@ static void destroy_func_cfg (gen_ctx_t gen_ctx) {
   }
   VARR_DESTROY (reg_info_t, curr_cfg->reg_info);
   bitmap_destroy (curr_cfg->call_crossed_regs);
-  free (curr_func_item->data);
+  gen_free (gen_ctx, curr_func_item->data);
   curr_func_item->data = NULL;
 }
 
@@ -1960,17 +1981,18 @@ static void solve_dataflow (gen_ctx_t gen_ctx, int forward_p, void (*con_func_0)
 }
 
 static void init_data_flow (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->data_flow_ctx = gen_malloc (gen_ctx, sizeof (struct data_flow_ctx));
-  VARR_CREATE (bb_t, worklist, 0);
-  VARR_CREATE (bb_t, pending, 0);
-  bb_to_consider = bitmap_create2 (512);
+  VARR_CREATE (bb_t, worklist, alloc, 0);
+  VARR_CREATE (bb_t, pending, alloc, 0);
+  bb_to_consider = bitmap_create2 (alloc, 512);
 }
 
 static void finish_data_flow (gen_ctx_t gen_ctx) {
   VARR_DESTROY (bb_t, worklist);
   VARR_DESTROY (bb_t, pending);
   bitmap_destroy (bb_to_consider);
-  free (gen_ctx->data_flow_ctx);
+  gen_free (gen_ctx, gen_ctx->data_flow_ctx);
   gen_ctx->data_flow_ctx = NULL;
 }
 
@@ -2060,7 +2082,7 @@ static int clone_bbs (gen_ctx_t gen_ctx) {
       });
       size++;
     }
-    delete_edge (e);
+    delete_edge (gen_ctx, e);
     gen_assert (last_dst_insn != NULL);
     if (last_dst_insn->code == MIR_JMP) {
       label = last_dst_insn->ops[0].u.label;
@@ -2395,9 +2417,9 @@ static ssa_edge_t add_ssa_edge_dup (gen_ctx_t gen_ctx, bb_insn_t def, int def_op
   return add_ssa_edge_1 (gen_ctx, def, def_op_num, use, use_op_num, TRUE);
 }
 
-static void free_ssa_edge (ssa_edge_t ssa_edge) { free (ssa_edge); }
+static void free_ssa_edge (gen_ctx_t gen_ctx, ssa_edge_t ssa_edge) { gen_free (gen_ctx, ssa_edge); }
 
-static void remove_ssa_edge (ssa_edge_t ssa_edge) {
+static void remove_ssa_edge (gen_ctx_t gen_ctx, ssa_edge_t ssa_edge) {
   if (ssa_edge->prev_use != NULL) {
     ssa_edge->prev_use->next_use = ssa_edge->next_use;
   } else {
@@ -2408,14 +2430,15 @@ static void remove_ssa_edge (ssa_edge_t ssa_edge) {
   if (ssa_edge->next_use != NULL) ssa_edge->next_use->prev_use = ssa_edge->prev_use;
   gen_assert (ssa_edge->use->insn->ops[ssa_edge->use_op_num].data == ssa_edge);
   ssa_edge->use->insn->ops[ssa_edge->use_op_num].data = NULL;
-  free_ssa_edge (ssa_edge);
+  free_ssa_edge (gen_ctx, ssa_edge);
 }
 
-static void remove_insn_ssa_edges (MIR_insn_t insn) {
+static void remove_insn_ssa_edges (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   ssa_edge_t ssa_edge;
   for (size_t i = 0; i < insn->nops; i++) {
     /* output operand refers to chain of ssa edges -- remove them all: */
-    while ((ssa_edge = insn->ops[i].data) != NULL) remove_ssa_edge (ssa_edge);
+    while ((ssa_edge = insn->ops[i].data) != NULL)
+      remove_ssa_edge (gen_ctx, ssa_edge);
   }
 }
 
@@ -2495,7 +2518,7 @@ static void make_ssa_def_use_repr (gen_ctx_t gen_ctx) {
 }
 
 static void ssa_delete_insn (gen_ctx_t gen_ctx, MIR_insn_t insn) {
-  remove_insn_ssa_edges (insn);
+  remove_insn_ssa_edges (gen_ctx, insn);
   gen_delete_insn (gen_ctx, insn);
 }
 
@@ -2755,14 +2778,14 @@ static void make_conventional_ssa (gen_ctx_t gen_ctx) { /* requires life info */
     }
 }
 
-static void free_fake_bb_insns (VARR (bb_insn_t) * bb_insns) {
+static void free_fake_bb_insns (gen_ctx_t gen_ctx, VARR (bb_insn_t) * bb_insns) {
   bb_insn_t bb_insn;
 
   while (VARR_LENGTH (bb_insn_t, bb_insns) != 0)
     if ((bb_insn = VARR_POP (bb_insn_t, bb_insns)) != NULL) {  // ??? specialized free funcs
-      remove_insn_ssa_edges (bb_insn->insn);
-      free (bb_insn->insn); /* we can not use gen_delete as the insn not in the list */
-      free (bb_insn);
+      remove_insn_ssa_edges (gen_ctx, bb_insn->insn);
+      gen_free (gen_ctx, bb_insn->insn); /* we can not use gen_delete as the insn not in the list */
+      gen_free (gen_ctx, bb_insn);
     }
 }
 
@@ -2775,8 +2798,8 @@ static void undo_build_ssa (gen_ctx_t gen_ctx) {
   MIR_insn_t insn;
   insn_var_iterator_t iter;
 
-  free_fake_bb_insns (arg_bb_insns);
-  free_fake_bb_insns (undef_insns);
+  free_fake_bb_insns (gen_ctx, arg_bb_insns);
+  free_fake_bb_insns (gen_ctx, undef_insns);
   for (bb = DLIST_HEAD (bb_t, curr_cfg->bbs); bb != NULL; bb = DLIST_NEXT (bb_t, bb))
     for (bb_insn = DLIST_HEAD (bb_insn_t, bb->bb_insns); bb_insn != NULL;
          bb_insn = DLIST_NEXT (bb_insn_t, bb_insn)) {
@@ -2785,7 +2808,7 @@ static void undo_build_ssa (gen_ctx_t gen_ctx) {
         /* all sse after ssa combine available only from defs */
         for (se = insn->ops[op_num].data; se != NULL; se = next_se) {
           next_se = se->next_use;
-          free_ssa_edge (se);
+          free_ssa_edge (gen_ctx, se);
         }
       }
       for (size_t i = 0; i < insn->nops; i++) insn->ops[i].data = NULL;
@@ -2798,15 +2821,16 @@ static void undo_build_ssa (gen_ctx_t gen_ctx) {
 }
 
 static void init_ssa (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->ssa_ctx = gen_malloc (gen_ctx, sizeof (struct ssa_ctx));
-  VARR_CREATE (bb_insn_t, arg_bb_insns, 0);
-  VARR_CREATE (bb_insn_t, undef_insns, 0);
-  VARR_CREATE (bb_insn_t, phis, 0);
-  VARR_CREATE (bb_insn_t, deleted_phis, 0);
-  HTAB_CREATE (def_tab_el_t, def_tab, 1024, def_tab_el_hash, def_tab_el_eq, gen_ctx);
-  VARR_CREATE (ssa_edge_t, ssa_edges_to_process, 512);
-  VARR_CREATE (size_t, curr_reg_indexes, 4096);
-  VARR_CREATE (char, reg_name, 20);
+  VARR_CREATE (bb_insn_t, arg_bb_insns, alloc, 0);
+  VARR_CREATE (bb_insn_t, undef_insns, alloc, 0);
+  VARR_CREATE (bb_insn_t, phis, alloc, 0);
+  VARR_CREATE (bb_insn_t, deleted_phis, alloc, 0);
+  HTAB_CREATE (def_tab_el_t, def_tab, alloc, 1024, def_tab_el_hash, def_tab_el_eq, gen_ctx);
+  VARR_CREATE (ssa_edge_t, ssa_edges_to_process, alloc, 512);
+  VARR_CREATE (size_t, curr_reg_indexes, alloc, 4096);
+  VARR_CREATE (char, reg_name, alloc, 20);
 }
 
 static void finish_ssa (gen_ctx_t gen_ctx) {
@@ -2818,7 +2842,7 @@ static void finish_ssa (gen_ctx_t gen_ctx) {
   VARR_DESTROY (ssa_edge_t, ssa_edges_to_process);
   VARR_DESTROY (size_t, curr_reg_indexes);
   VARR_DESTROY (char, reg_name);
-  free (gen_ctx->ssa_ctx);
+  gen_free (gen_ctx, gen_ctx->ssa_ctx);
   gen_ctx->ssa_ctx = NULL;
 }
 
@@ -2920,7 +2944,7 @@ static void transform_addrs (gen_ctx_t gen_ctx) {
         for (size_t i = 0; i < insn->nops; i++) {
           gen_assert (insn->ops[i].mode == MIR_OP_VAR);
           if (!bitmap_bit_p (addr_regs, insn->ops[i].u.var)) continue;
-          remove_ssa_edge (insn->ops[i].data);
+          remove_ssa_edge (gen_ctx, insn->ops[i].data);
           for (size_t j = i; j + 1 < insn->nops; j++) insn->ops[j] = insn->ops[j + 1];
           change_p = TRUE;
           i--;
@@ -2973,7 +2997,8 @@ static void transform_addrs (gen_ctx_t gen_ctx) {
             gen_add_insn_after (gen_ctx, insn, new_insn);
             gen_assert (insn->ops[op_num].mode == MIR_OP_VAR);
             insn->ops[op_num].u.var = new_reg;
-            while ((se = insn->ops[op_num].data) != NULL) remove_ssa_edge (se);
+            while ((se = insn->ops[op_num].data) != NULL)
+              remove_ssa_edge (gen_ctx, se);
             if (!ssa_rebuild_p) {
               add_ssa_edge (gen_ctx, addr_insn->data, 0, new_insn->data, 0);
               add_ssa_edge (gen_ctx, bb_insn, op_num, new_insn->data, 1);
@@ -2989,7 +3014,8 @@ static void transform_addrs (gen_ctx_t gen_ctx) {
                           && insn->ops[op_num].u.var_mem.base == reg);
               insn->ops[op_num].u.var_mem.base = new_reg;
             }
-            if (insn->ops[op_num].data != NULL) remove_ssa_edge (insn->ops[op_num].data);
+            if (insn->ops[op_num].data != NULL)
+              remove_ssa_edge (gen_ctx,insn->ops[op_num].data);
             if (!ssa_rebuild_p) {
               add_ssa_edge (gen_ctx, addr_insn->data, 0, new_insn->data, 1);
               add_ssa_edge (gen_ctx, new_insn->data, 0, bb_insn, op_num);
@@ -3023,7 +3049,8 @@ static void transform_addrs (gen_ctx_t gen_ctx) {
           case MIR_T_U32: use_insn->code = MIR_UEXT32; break;
           default: break;
           }
-          if (use_insn->ops[op_num].data != NULL) remove_ssa_edge (use_insn->ops[op_num].data);
+          if (use_insn->ops[op_num].data != NULL)
+            remove_ssa_edge (gen_ctx, use_insn->ops[op_num].data);
           use_insn->ops[op_num].mode = MIR_OP_VAR;
           use_insn->ops[op_num].u.var = insn->ops[1].u.var;
           if (!ssa_rebuild_p) add_ssa_edge (gen_ctx, se->def, se->def_op_num, use_bb_insn, op_num);
@@ -3220,7 +3247,7 @@ static void copy_prop (gen_ctx_t gen_ctx) {
           });
           new_reg = def_insn->ops[1].u.var;
           gen_assert (reg > MAX_HARD_REG && new_reg > MAX_HARD_REG);
-          remove_ssa_edge (se);
+          remove_ssa_edge (gen_ctx, se);
           se = def_insn->ops[1].data;
           add_ssa_edge (gen_ctx, se->def, se->def_op_num, bb_insn, op_num);
           rename_op_reg (gen_ctx, &insn->ops[op_num], reg, new_reg, insn, TRUE);
@@ -3235,7 +3262,7 @@ static void copy_prop (gen_ctx_t gen_ctx) {
               || se->next_use->use == DLIST_NEXT (bb_insn_t, bb_insn))) {
         /* a = ...; non-dead insn: b = a; ... = a & only two uses of a =>  b = ...; ... = b */
         MIR_op_t *def_op_ref = &se->def->insn->ops[se->def_op_num];
-        remove_ssa_edge (insn->ops[1].data);
+        remove_ssa_edge (gen_ctx, insn->ops[1].data);
         se = def_op_ref->data;
         gen_assert (se != NULL && se->next_use == NULL
                     && se->use == DLIST_NEXT (bb_insn_t, bb_insn));
@@ -3283,7 +3310,7 @@ static void copy_prop (gen_ctx_t gen_ctx) {
           MIR_output_insn (ctx, debug_file, insn, func, FALSE);
         });
         insn->ops[1].u.var = def_insn->ops[1].u.var;
-        remove_ssa_edge (se);
+        remove_ssa_edge (gen_ctx, se);
         se = def_insn->ops[1].data;
         add_ssa_edge (gen_ctx, se->def, se->def_op_num, bb_insn, 1);
         DEBUG (2, {
@@ -3301,7 +3328,7 @@ static void copy_prop (gen_ctx_t gen_ctx) {
         });
         insn->code = def_insn->code;
         insn->ops[1].u.var = def_insn->ops[1].u.var;
-        remove_ssa_edge (se);
+        remove_ssa_edge (gen_ctx, se);
         se = def_insn->ops[1].data;
         add_ssa_edge (gen_ctx, se->def, se->def_op_num, bb_insn, 1);
         DEBUG (2, {
@@ -3333,7 +3360,7 @@ static void copy_prop (gen_ctx_t gen_ctx) {
                                  _MIR_new_var_op (ctx, def_insn->ops[1].u.var),
                                  _MIR_new_var_op (ctx, new_reg));
         gen_add_insn_before (gen_ctx, insn, new_insn);
-        remove_ssa_edge (se);                                         /* r1 */
+        remove_ssa_edge (gen_ctx, se);                                         /* r1 */
         add_ssa_edge (gen_ctx, mov_insn->data, 0, new_insn->data, 2); /* t */
         se = def_insn->ops[1].data;
         add_ssa_edge (gen_ctx, se->def, se->def_op_num, new_insn->data, 1); /* r2 */
@@ -4038,7 +4065,7 @@ static int gvn_phi_val (bb_insn_t phi, int64_t *val) {
   return same_p && const_p;
 }
 
-static void remove_edge_phi_ops (edge_t e) {
+static void remove_edge_phi_ops (gen_ctx_t gen_ctx, edge_t e) {
   size_t i, nop;
   edge_t e2;
   MIR_insn_t insn;
@@ -4052,7 +4079,8 @@ static void remove_edge_phi_ops (edge_t e) {
        bb_insn = DLIST_NEXT (bb_insn_t, bb_insn)) {
     if ((insn = bb_insn->insn)->code == MIR_LABEL) continue;
     if (insn->code != MIR_PHI) break;
-    if ((se = insn->ops[nop].data) != NULL) remove_ssa_edge (se);
+    if ((se = insn->ops[nop].data) != NULL)
+      remove_ssa_edge (gen_ctx, se);
     for (i = nop; i + 1 < insn->nops; i++) {
       insn->ops[i] = insn->ops[i + 1];
       /* se can be null from some previously removed BB insn: */
@@ -4065,9 +4093,9 @@ static void remove_edge_phi_ops (edge_t e) {
   }
 }
 
-static void MIR_UNUSED remove_dest_phi_ops (bb_t bb) {
+static void MIR_UNUSED remove_dest_phi_ops (gen_ctx_t gen_ctx, bb_t bb) {
   for (edge_t e = DLIST_HEAD (out_edge_t, bb->out_edges); e != NULL; e = DLIST_NEXT (out_edge_t, e))
-    remove_edge_phi_ops (e);
+    remove_edge_phi_ops (gen_ctx, e);
 }
 
 static void set_alloca_based_flag (bb_insn_t bb_insn, int must_p) {
@@ -4237,7 +4265,7 @@ static void remove_copy (gen_ctx_t gen_ctx, MIR_insn_t insn) {
   se = insn->ops[1].data;
   def = se->def;
   def_op_num = se->def_op_num;
-  remove_ssa_edge (se);
+  remove_ssa_edge (gen_ctx, se);
   if ((last_se = def->insn->ops[def_op_num].data) != NULL)
     while (last_se->next_use != NULL) last_se = last_se->next_use;
   change_ssa_edge_list_def (insn->ops[0].data, def, def_op_num, insn->ops[0].u.var,
@@ -4303,10 +4331,10 @@ static void remove_unreachable_bb_edges (gen_ctx_t gen_ctx, bb_t bb, VARR (bb_t)
     });
     for (e = DLIST_HEAD (out_edge_t, bb->out_edges); e != NULL; e = next_e) {
       next_e = DLIST_NEXT (out_edge_t, e);
-      remove_edge_phi_ops (e);
+      remove_edge_phi_ops (gen_ctx, e);
       dst = e->dst;
       dst->flag = TRUE; /* to recalculate dst mem_av_in */
-      delete_edge (e);
+      delete_edge (gen_ctx, e);
       if (dst->index > 2 && DLIST_HEAD (in_edge_t, dst->in_edges) == NULL)
         VARR_PUSH (bb_t, bbs, dst);
     }
@@ -4677,7 +4705,7 @@ static void gvn_modify (gen_ctx_t gen_ctx) {
               }
               bitmap_clear_bit_p (curr_available_mem, bb_insn->mem_index);
               bitmap_set_bit_p (removed_mem, bb_insn->mem_index);
-              remove_ssa_edge ((ssa_edge_t) insn->ops[1].data);
+              remove_ssa_edge (gen_ctx, (ssa_edge_t) insn->ops[1].data);
               insn->ops[1] = _MIR_new_var_op (ctx, temp_reg); /* changing mem */
               def_insn = DLIST_NEXT (MIR_insn_t, mem_insn);
               add_ssa_edge (gen_ctx, def_insn->data, 0, bb_insn, 1);
@@ -4752,9 +4780,9 @@ static void gvn_modify (gen_ctx_t gen_ctx) {
             });
             ssa_delete_insn (gen_ctx, insn);
             edge_t edge = DLIST_EL (out_edge_t, bb->out_edges, 1);
-            remove_edge_phi_ops (edge);
+            remove_edge_phi_ops (gen_ctx, edge);
             edge->dst->flag = TRUE; /* to recalculate dst mem_av_in */
-            delete_edge (edge);
+            delete_edge (gen_ctx, edge);
             deleted_branches_num++;
           } else {
             new_insn = MIR_new_insn (ctx, MIR_JMP, insn->ops[0]); /* label is always 0-th op */
@@ -4766,14 +4794,14 @@ static void gvn_modify (gen_ctx_t gen_ctx) {
               fprintf (debug_file, "\n");
             });
             MIR_insert_insn_before (ctx, curr_func_item, insn, new_insn);
-            remove_insn_ssa_edges (insn);
+            remove_insn_ssa_edges (gen_ctx, insn);
             MIR_remove_insn (ctx, curr_func_item, insn);
             new_insn->data = bb_insn;
             bb_insn->insn = new_insn;
             edge_t edge = DLIST_EL (out_edge_t, bb->out_edges, 0);
-            remove_edge_phi_ops (edge);
+            remove_edge_phi_ops (gen_ctx, edge);
             edge->dst->flag = TRUE; /* to recalculate dst mem_av_in */
-            delete_edge (edge);
+            delete_edge (gen_ctx, edge);
           }
         } else { /* x=... and x is const => x=...; x=const */
           new_insn = MIR_new_insn (ctx, MIR_MOV, insn->ops[0], MIR_new_int_op (ctx, val));
@@ -4897,34 +4925,35 @@ static void gvn (gen_ctx_t gen_ctx) {
 
 static void gvn_clear (gen_ctx_t gen_ctx) {
   HTAB_CLEAR (expr_t, expr_tab);
-  while (VARR_LENGTH (expr_t, exprs) != 0) free (VARR_POP (expr_t, exprs));
+  while (VARR_LENGTH (expr_t, exprs) != 0) gen_free (gen_ctx, VARR_POP (expr_t, exprs));
   HTAB_CLEAR (mem_expr_t, mem_expr_tab);
-  while (VARR_LENGTH (mem_expr_t, mem_exprs) != 0) free (VARR_POP (mem_expr_t, mem_exprs));
+  while (VARR_LENGTH (mem_expr_t, mem_exprs) != 0) gen_free (gen_ctx, VARR_POP (mem_expr_t, mem_exprs));
 }
 
 static void init_gvn (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
 
   gen_ctx->gvn_ctx = gen_malloc (gen_ctx, sizeof (struct gvn_ctx));
-  VARR_CREATE (expr_t, exprs, 512);
-  HTAB_CREATE (expr_t, expr_tab, 1024, expr_hash, expr_eq, gen_ctx);
+  VARR_CREATE (expr_t, exprs, alloc, 512);
+  HTAB_CREATE (expr_t, expr_tab, alloc, 1024, expr_hash, expr_eq, gen_ctx);
   temp_mem_insn
     = MIR_new_insn (ctx, MIR_MOV,
                     _MIR_new_var_mem_op (ctx, MIR_T_I64, 0, MIR_NON_VAR, MIR_NON_VAR, 0),
                     _MIR_new_var_op (ctx, 0));
-  VARR_CREATE (mem_expr_t, mem_exprs, 256);
-  HTAB_CREATE (mem_expr_t, mem_expr_tab, 512, mem_expr_hash, mem_expr_eq, gen_ctx);
-  VARR_CREATE (insn_nop_pair_t, insn_nop_pairs, 16);
+  VARR_CREATE (mem_expr_t, mem_exprs, alloc, 256);
+  HTAB_CREATE (mem_expr_t, mem_expr_tab, alloc, 512, mem_expr_hash, mem_expr_eq, gen_ctx);
+  VARR_CREATE (insn_nop_pair_t, insn_nop_pairs, alloc, 16);
 }
 
 static void finish_gvn (gen_ctx_t gen_ctx) {
   VARR_DESTROY (expr_t, exprs);
   HTAB_DESTROY (expr_t, expr_tab);
-  free (temp_mem_insn); /* ??? */
+  gen_free (gen_ctx, temp_mem_insn); /* ??? */
   VARR_DESTROY (mem_expr_t, mem_exprs);
   HTAB_DESTROY (mem_expr_t, mem_expr_tab);
   VARR_DESTROY (insn_nop_pair_t, insn_nop_pairs);
-  free (gen_ctx->gvn_ctx);
+  gen_free (gen_ctx, gen_ctx->gvn_ctx);
   gen_ctx->gvn_ctx = NULL;
 }
 
@@ -5213,7 +5242,7 @@ static void ssa_dead_code_elimination (gen_ctx_t gen_ctx) {
     FOREACH_IN_INSN_VAR (gen_ctx, iter, insn, var, op_num) {
       if ((ssa_edge = insn->ops[op_num].data) == NULL) continue;
       def = ssa_edge->def;
-      remove_ssa_edge (ssa_edge);
+      remove_ssa_edge (gen_ctx, ssa_edge);
       if (ssa_dead_insn_p (gen_ctx, def)) VARR_PUSH (bb_insn_t, temp_bb_insns, def);
     }
     gen_delete_insn (gen_ctx, insn);
@@ -5262,7 +5291,7 @@ static void create_preheader_from_edge (gen_ctx_t gen_ctx, edge_t e, loop_node_t
   loop->u.preheader = bb_loop_node;
   create_edge (gen_ctx, e->src, new_bb, TRUE, FALSE); /* fall through should be the 1st edge */
   create_edge (gen_ctx, new_bb, e->dst, TRUE, FALSE);
-  delete_edge (e);
+  delete_edge (gen_ctx, e);
 }
 
 static void licm_add_loop_preheaders (gen_ctx_t gen_ctx, loop_node_t loop) {
@@ -5833,7 +5862,7 @@ static void ssa_combine (gen_ctx_t gen_ctx) {  // tied reg, alias ???
       for (size_t i = 0; i < insn->nops; i++) {
         if (insn->ops[i].mode != MIR_OP_VAR_MEM) continue;
         if (!update_addr_p (gen_ctx, bb, &insn->ops[i], &temp_op, &addr_info)) continue;
-        remove_ssa_edge (insn->ops[i].data);
+        remove_ssa_edge (gen_ctx, insn->ops[i].data);
         insn->ops[i].u.var_mem.disp = addr_info.disp;
         insn->ops[i].u.var_mem.base = insn->ops[i].u.var_mem.index = MIR_NON_VAR;
         if (addr_info.base != NULL) {
@@ -6143,6 +6172,7 @@ static int consider_move_vars_only (gen_ctx_t gen_ctx) {
 }
 
 static void add_bb_insn_dead_vars (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_insn_t insn;
   bb_insn_t bb_insn, prev_bb_insn;
   MIR_reg_t var, early_clobbered_hard_reg1, early_clobbered_hard_reg2;
@@ -6152,7 +6182,7 @@ static void add_bb_insn_dead_vars (gen_ctx_t gen_ctx) {
 
   /* we need all var analysis and bb insns to keep dead var info */
   gen_assert (optimize_level > 0);
-  live = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
+  live = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
   for (bb_t bb = DLIST_HEAD (bb_t, curr_cfg->bbs); bb != NULL; bb = DLIST_NEXT (bb_t, bb)) {
     bitmap_copy (live, bb->live_out);
     for (bb_insn = DLIST_TAIL (bb_insn_t, bb->bb_insns); bb_insn != NULL; bb_insn = prev_bb_insn) {
@@ -6233,7 +6263,7 @@ static void init_lr_bbs (gen_ctx_t gen_ctx) { free_lr_bb_list = NULL; }
 static void finish_lr_bbs (gen_ctx_t gen_ctx) {
   for (lr_bb_t lr_bb = free_lr_bb_list; lr_bb != NULL; lr_bb = free_lr_bb_list) {
     free_lr_bb_list = lr_bb->next;
-    free (lr_bb);
+    gen_free (gen_ctx, lr_bb);
   }
 }
 
@@ -6282,7 +6312,7 @@ static void init_lrs (gen_ctx_t gen_ctx) { free_lr_list = NULL; }
 static void finish_lrs (gen_ctx_t gen_ctx) {
   for (live_range_t lr = free_lr_list; lr != NULL; lr = free_lr_list) {
     free_lr_list = lr->next;
-    free (lr);
+    gen_free (gen_ctx, lr);
   }
 }
 
@@ -6571,18 +6601,19 @@ static void free_func_live_ranges (gen_ctx_t gen_ctx) {
 }
 
 static void init_live_ranges (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->lr_ctx = gen_malloc (gen_ctx, sizeof (struct lr_ctx));
-  VARR_CREATE (int, var_to_scan_var_map, 0);
-  VARR_CREATE (MIR_reg_t, scan_var_to_var_map, 0);
+  VARR_CREATE (int, var_to_scan_var_map, alloc, 0);
+  VARR_CREATE (MIR_reg_t, scan_var_to_var_map, alloc, 0);
   init_lr_bbs (gen_ctx);
   init_lrs (gen_ctx);
-  VARR_CREATE (live_range_t, var_live_ranges, 0);
-  VARR_CREATE (int, point_map, 1024);
-  live_vars = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  referenced_vars = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  points_with_born_vars = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  points_with_dead_vars = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  points_with_born_or_dead_vars = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
+  VARR_CREATE (live_range_t, var_live_ranges, alloc, 0);
+  VARR_CREATE (int, point_map, alloc, 1024);
+  live_vars = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  referenced_vars = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  points_with_born_vars = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  points_with_dead_vars = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  points_with_born_or_dead_vars = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
 }
 
 static void finish_live_ranges (gen_ctx_t gen_ctx) {
@@ -6597,7 +6628,7 @@ static void finish_live_ranges (gen_ctx_t gen_ctx) {
   finish_lr_bbs (gen_ctx);
   VARR_DESTROY (int, var_to_scan_var_map);
   VARR_DESTROY (MIR_reg_t, scan_var_to_var_map);
-  free (gen_ctx->lr_ctx);
+  gen_free (gen_ctx, gen_ctx->lr_ctx);
   gen_ctx->lr_ctx = NULL;
 }
 
@@ -6673,7 +6704,7 @@ static void jump_opt (gen_ctx_t gen_ctx) {
       out_e->fall_through_p = TRUE;
       e = DLIST_NEXT (out_edge_t, out_e);
       gen_assert (e == NULL || DLIST_NEXT (out_edge_t, e) == NULL);
-      if (e != NULL) delete_edge (e);
+      if (e != NULL) delete_edge (gen_ctx, e);
       gen_delete_insn (gen_ctx, insn);
       next_bb = bb; /* bb can became empty after removing jump.  */
     } else {
@@ -7017,11 +7048,12 @@ static void coalesce (gen_ctx_t gen_ctx) {
 #undef live_out
 
 static void init_coalesce (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->coalesce_ctx = gen_malloc (gen_ctx, sizeof (struct coalesce_ctx));
-  VARR_CREATE (mv_t, moves, 0);
-  VARR_CREATE (MIR_reg_t, first_coalesced_reg, 0);
-  VARR_CREATE (MIR_reg_t, next_coalesced_reg, 0);
-  conflict_matrix = bitmap_create ();
+  VARR_CREATE (mv_t, moves, alloc, 0);
+  VARR_CREATE (MIR_reg_t, first_coalesced_reg, alloc, 0);
+  VARR_CREATE (MIR_reg_t, next_coalesced_reg, alloc, 0);
+  conflict_matrix = bitmap_create (alloc);
 }
 
 static void finish_coalesce (gen_ctx_t gen_ctx) {
@@ -7029,7 +7061,7 @@ static void finish_coalesce (gen_ctx_t gen_ctx) {
   VARR_DESTROY (MIR_reg_t, first_coalesced_reg);
   VARR_DESTROY (MIR_reg_t, next_coalesced_reg);
   bitmap_destroy (conflict_matrix);
-  free (gen_ctx->coalesce_ctx);
+  gen_free (gen_ctx, gen_ctx->coalesce_ctx);
   gen_ctx->coalesce_ctx = NULL;
 }
 
@@ -7245,9 +7277,11 @@ static int lr_gap_eq (lr_gap_t el1, lr_gap_t el2, void *arg MIR_UNUSED) {
 
 static void insert_lr_gap (gen_ctx_t gen_ctx, int hreg, MIR_type_t type, MIR_reg_t reg,
                            live_range_t lr) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   lr_gap_t el = {hreg, type, reg, lr}, tab_el;
   gen_assert (lr->lr_bb != NULL);
-  if (lr_gap_bitmaps[hreg] == NULL) lr_gap_bitmaps[hreg] = bitmap_create2 (3 * lr->start / 2);
+  if (lr_gap_bitmaps[hreg] == NULL)
+    lr_gap_bitmaps[hreg] = bitmap_create2 (alloc, 3 * lr->start / 2);
   bitmap_set_bit_p (lr_gap_bitmaps[hreg], lr->start);
   HTAB_DO (lr_gap_t, lr_gap_tab, el, HTAB_INSERT, tab_el);
 }
@@ -7272,8 +7306,9 @@ static inline int find_lr_gap (gen_ctx_t gen_ctx, int hreg, int point, lr_gap_t 
 }
 
 static void init_lr_gap_tab (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   for (int i = 0; i <= MAX_HARD_REG; i++) lr_gap_bitmaps[i] = NULL;
-  HTAB_CREATE (lr_gap_t, lr_gap_tab, 1024, lr_gap_hash, lr_gap_eq, NULL);
+  HTAB_CREATE (lr_gap_t, lr_gap_tab, alloc, 1024, lr_gap_hash, lr_gap_eq, NULL);
 }
 
 static void finish_lr_gap_tab (gen_ctx_t gen_ctx) {
@@ -7514,6 +7549,7 @@ static MIR_reg_t get_stack_loc (gen_ctx_t gen_ctx, MIR_reg_t start_loc, MIR_type
 #define ONLY_SIMPLIFIED_RA FALSE
 
 static void assign (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_context_t ctx = gen_ctx->ctx;
   MIR_reg_t best_loc, i, reg, var, max_var = get_max_var (gen_ctx);
   MIR_type_t type;
@@ -7569,11 +7605,11 @@ static void assign (gen_ctx_t gen_ctx) {
       if (!simplified_p) bitmap_copy (VARR_GET (bitmap_t, busy_used_locs, n), global_hard_regs);
     }
   while ((int) VARR_LENGTH (bitmap_t, used_locs) <= curr_point) {
-    bm = bitmap_create2 (MAX_HARD_REG + 1);
+    bm = bitmap_create2 (alloc, MAX_HARD_REG + 1);
     if (global_hard_regs != NULL) bitmap_copy (bm, global_hard_regs);
     VARR_PUSH (bitmap_t, used_locs, bm);
     if (!simplified_p) {
-      bm = bitmap_create2 (MAX_HARD_REG + 1);
+      bm = bitmap_create2 (alloc, MAX_HARD_REG + 1);
       if (global_hard_regs != NULL) bitmap_copy (bm, global_hard_regs);
       VARR_PUSH (bitmap_t, busy_used_locs, bm);
     }
@@ -8512,19 +8548,20 @@ static void reg_alloc (gen_ctx_t gen_ctx) {
 }
 
 static void init_ra (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->ra_ctx = gen_malloc (gen_ctx, sizeof (struct ra_ctx));
-  VARR_CREATE (MIR_reg_t, reg_renumber, 0);
-  VARR_CREATE (allocno_info_t, sorted_regs, 0);
-  VARR_CREATE (bitmap_t, used_locs, 0);
-  VARR_CREATE (bitmap_t, busy_used_locs, 0);
-  VARR_CREATE (bitmap_t, var_bbs, 0);
-  VARR_CREATE (lr_gap_t, spill_gaps, 0);
-  VARR_CREATE (lr_gap_t, curr_gaps, 0);
-  VARR_CREATE (spill_el_t, spill_els, 0);
+  VARR_CREATE (MIR_reg_t, reg_renumber, alloc, 0);
+  VARR_CREATE (allocno_info_t, sorted_regs, alloc, 0);
+  VARR_CREATE (bitmap_t, used_locs, alloc, 0);
+  VARR_CREATE (bitmap_t, busy_used_locs, alloc, 0);
+  VARR_CREATE (bitmap_t, var_bbs, alloc, 0);
+  VARR_CREATE (lr_gap_t, spill_gaps, alloc, 0);
+  VARR_CREATE (lr_gap_t, curr_gaps, alloc, 0);
+  VARR_CREATE (spill_el_t, spill_els, alloc, 0);
   init_lr_gap_tab (gen_ctx);
-  VARR_CREATE (spill_cache_el_t, spill_cache, 0);
+  VARR_CREATE (spill_cache_el_t, spill_cache, alloc, 0);
   spill_cache_age = 0;
-  conflict_locs1 = bitmap_create2 (3 * MAX_HARD_REG / 2);
+  conflict_locs1 = bitmap_create2 (alloc, 3 * MAX_HARD_REG / 2);
 }
 
 static void finish_ra (gen_ctx_t gen_ctx) {
@@ -8543,7 +8580,7 @@ static void finish_ra (gen_ctx_t gen_ctx) {
   finish_lr_gap_tab (gen_ctx);
   VARR_DESTROY (spill_cache_el_t, spill_cache);
   bitmap_destroy (conflict_locs1);
-  free (gen_ctx->ra_ctx);
+  gen_free (gen_ctx, gen_ctx->ra_ctx);
   gen_ctx->ra_ctx = NULL;
 }
 
@@ -9101,14 +9138,15 @@ static void combine (gen_ctx_t gen_ctx, int no_property_p) {
 }
 
 static void init_combine (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   gen_ctx->combine_ctx = gen_malloc (gen_ctx, sizeof (struct combine_ctx));
   curr_bb_var_ref_age = 0;
-  VARR_CREATE (size_t, var_ref_ages, 0);
-  VARR_CREATE (var_ref_t, var_refs, 0);
-  VARR_CREATE (MIR_reg_t, insn_vars, 0);
-  VARR_CREATE (size_t, changed_op_numbers, 16);
-  VARR_CREATE (MIR_op_t, last_right_ops, 16);
-  vars_bitmap = bitmap_create ();
+  VARR_CREATE (size_t, var_ref_ages, alloc, 0);
+  VARR_CREATE (var_ref_t, var_refs, alloc, 0);
+  VARR_CREATE (MIR_reg_t, insn_vars, alloc, 0);
+  VARR_CREATE (size_t, changed_op_numbers, alloc, 16);
+  VARR_CREATE (MIR_op_t, last_right_ops, alloc, 16);
+  vars_bitmap = bitmap_create (alloc);
 }
 
 static void finish_combine (gen_ctx_t gen_ctx) {
@@ -9118,7 +9156,7 @@ static void finish_combine (gen_ctx_t gen_ctx) {
   VARR_DESTROY (size_t, changed_op_numbers);
   VARR_DESTROY (MIR_op_t, last_right_ops);
   bitmap_destroy (vars_bitmap);
-  free (gen_ctx->combine_ctx);
+  gen_free (gen_ctx, gen_ctx->combine_ctx);
   gen_ctx->combine_ctx = NULL;
 }
 
@@ -9139,6 +9177,7 @@ static void remove_property_insns (gen_ctx_t gen_ctx) {
 #define live_out out
 
 static void dead_code_elimination (gen_ctx_t gen_ctx) {
+  MIR_alloc_t alloc = gen_alloc (gen_ctx);
   MIR_insn_t insn, nop_insn;
   bb_insn_t bb_insn, prev_bb_insn;
   MIR_reg_t var, early_clobbered_hard_reg1, early_clobbered_hard_reg2;
@@ -9151,7 +9190,7 @@ static void dead_code_elimination (gen_ctx_t gen_ctx) {
 
   gen_assert (optimize_level > 0);
   DEBUG (2, { fprintf (debug_file, "+++++++++++++Dead code elimination:\n"); });
-  live = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
+  live = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
   for (bb_t bb = DLIST_HEAD (bb_t, curr_cfg->bbs); bb != NULL; bb = DLIST_NEXT (bb_t, bb)) {
     bitmap_copy (live, bb->live_out);
     for (bb_insn = DLIST_TAIL (bb_insn_t, bb->bb_insns); bb_insn != NULL; bb_insn = prev_bb_insn) {
@@ -9592,9 +9631,12 @@ static void create_bb_stubs (gen_ctx_t gen_ctx) {
 }
 
 void MIR_gen_init (MIR_context_t ctx) {
+  MIR_alloc_t alloc = MIR_get_alloc (ctx);
   gen_ctx_t gen_ctx, *gen_ctx_ptr = gen_ctx_loc (ctx);
 
-  *gen_ctx_ptr = gen_ctx = gen_malloc (NULL, sizeof (struct gen_ctx));
+  *gen_ctx_ptr = gen_ctx = MIR_malloc (alloc, sizeof (struct gen_ctx));
+  if (gen_ctx == NULL) util_error (gen_ctx, "no memory");
+
   gen_ctx->ctx = ctx;
   optimize_level = 2;
   gen_ctx->target_ctx = NULL;
@@ -9607,24 +9649,24 @@ void MIR_gen_init (MIR_context_t ctx) {
   debug_file = NULL;
   debug_level = 100;
 #endif
-  VARR_CREATE (void_ptr_t, to_free, 0);
+  VARR_CREATE (void_ptr_t, to_free, alloc, 0);
   addr_insn_p = FALSE;
-  VARR_CREATE (MIR_op_t, temp_ops, 16);
-  VARR_CREATE (MIR_insn_t, temp_insns, 16);
-  VARR_CREATE (MIR_insn_t, temp_insns2, 16);
-  VARR_CREATE (bb_insn_t, temp_bb_insns, 16);
-  VARR_CREATE (bb_insn_t, temp_bb_insns2, 16);
-  VARR_CREATE (loop_node_t, loop_nodes, 32);
-  VARR_CREATE (loop_node_t, queue_nodes, 32);
-  VARR_CREATE (loop_node_t, loop_entries, 16);
-  VARR_CREATE (mem_attr_t, mem_attrs, 32);
-  VARR_CREATE (target_bb_version_t, target_succ_bb_versions, 16);
-  VARR_CREATE (void_ptr_t, succ_bb_addrs, 16);
-  VARR_CREATE (spot_attr_t, spot_attrs, 32);
-  VARR_CREATE (spot_attr_t, spot2attr, 32);
-  temp_bitmap = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  temp_bitmap2 = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
-  temp_bitmap3 = bitmap_create2 (DEFAULT_INIT_BITMAP_BITS_NUM);
+  VARR_CREATE (MIR_op_t, temp_ops, alloc, 16);
+  VARR_CREATE (MIR_insn_t, temp_insns, alloc, 16);
+  VARR_CREATE (MIR_insn_t, temp_insns2, alloc, 16);
+  VARR_CREATE (bb_insn_t, temp_bb_insns, alloc, 16);
+  VARR_CREATE (bb_insn_t, temp_bb_insns2, alloc, 16);
+  VARR_CREATE (loop_node_t, loop_nodes, alloc, 32);
+  VARR_CREATE (loop_node_t, queue_nodes, alloc, 32);
+  VARR_CREATE (loop_node_t, loop_entries, alloc, 16);
+  VARR_CREATE (mem_attr_t, mem_attrs, alloc, 32);
+  VARR_CREATE (target_bb_version_t, target_succ_bb_versions, alloc, 16);
+  VARR_CREATE (void_ptr_t, succ_bb_addrs, alloc, 16);
+  VARR_CREATE (spot_attr_t, spot_attrs, alloc, 32);
+  VARR_CREATE (spot_attr_t, spot2attr, alloc, 32);
+  temp_bitmap = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  temp_bitmap2 = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
+  temp_bitmap3 = bitmap_create2 (alloc, DEFAULT_INIT_BITMAP_BITS_NUM);
   init_dead_vars (gen_ctx);
   init_data_flow (gen_ctx);
   init_ssa (gen_ctx);
@@ -9640,16 +9682,16 @@ void MIR_gen_init (MIR_context_t ctx) {
     target_hard_reg_type_ok_p (i, MIR_T_I32) ? max_int_hard_regs++ : max_fp_hard_regs++;
   }
   for (MIR_type_t type = MIR_T_I8; type < MIR_T_BOUND; type++) {
-    call_used_hard_regs[type] = bitmap_create2 (MAX_HARD_REG + 1);
+    call_used_hard_regs[type] = bitmap_create2 (alloc, MAX_HARD_REG + 1);
     for (int i = 0; i <= MAX_HARD_REG; i++) {
       /* We need call_used_hard_regs even for fixed regs in combine. */
       if (target_call_used_hard_reg_p (i, type)) bitmap_set_bit_p (call_used_hard_regs[type], i);
     }
   }
-  tied_regs = bitmap_create2 (256);
-  addr_regs = bitmap_create2 (256);
-  insn_to_consider = bitmap_create2 (1024);
-  func_used_hard_regs = bitmap_create2 (MAX_HARD_REG + 1);
+  tied_regs = bitmap_create2 (alloc, 256);
+  addr_regs = bitmap_create2 (alloc, 256);
+  insn_to_consider = bitmap_create2 (alloc, 1024);
+  func_used_hard_regs = bitmap_create2 (alloc, MAX_HARD_REG + 1);
   bb_wrapper = _MIR_get_bb_wrapper (ctx, gen_ctx, bb_version_generator);
   overall_bbs_num = overall_gen_bbs_num = 0;
 }
@@ -9676,7 +9718,7 @@ void MIR_gen_finish (MIR_context_t ctx) {
   bitmap_destroy (func_used_hard_regs);
   target_finish (gen_ctx);
   finish_dead_vars (gen_ctx);
-  free (gen_ctx->data_flow_ctx);
+  gen_free (gen_ctx, gen_ctx->data_flow_ctx);
   bitmap_destroy (temp_bitmap);
   bitmap_destroy (temp_bitmap2);
   bitmap_destroy (temp_bitmap3);
@@ -9693,12 +9735,12 @@ void MIR_gen_finish (MIR_context_t ctx) {
   VARR_DESTROY (void_ptr_t, succ_bb_addrs);
   VARR_DESTROY (spot_attr_t, spot_attrs);
   VARR_DESTROY (spot_attr_t, spot2attr);
-  while (VARR_LENGTH (void_ptr_t, to_free) != 0) free (VARR_POP (void_ptr_t, to_free));
+  while (VARR_LENGTH (void_ptr_t, to_free) != 0) gen_free (gen_ctx, VARR_POP (void_ptr_t, to_free));
   VARR_DESTROY (void_ptr_t, to_free);
   if (collect_bb_stat_p)
     fprintf (stderr, "Overall bbs num = %llu, generated bbs num = %llu\n", overall_bbs_num,
              overall_gen_bbs_num);
-  free (gen_ctx);
+  gen_free (gen_ctx, gen_ctx);
   *gen_ctx_ptr = NULL;
 }
 

--- a/mir-htab.h
+++ b/mir-htab.h
@@ -5,6 +5,7 @@
 #ifndef MIR_HTAB_H
 #define MIR_HTAB_H
 
+#include "mir-alloc.h"
 #include "mir-varr.h"
 
 #ifdef __cplusplus
@@ -87,7 +88,8 @@ DEF_VARR (htab_ind_t)
 #define DEF_HTAB(T)                                                                              \
   HTAB_T (T)                                                                                     \
                                                                                                  \
-  static inline void HTAB_OP_DEF (T, create) (HTAB (T) * *htab, htab_size_t min_size,            \
+  static inline void HTAB_OP_DEF (T, create) (HTAB (T) * *htab, MIR_alloc_t alloc,               \
+                                              htab_size_t min_size,                              \
                                               htab_hash_t (*hash_func) (T el, void *arg),        \
                                               int (*eq_func) (T el1, T el2, void *arg),          \
                                               void (*free_func) (T el, void *arg), void *arg) {  \
@@ -96,11 +98,11 @@ DEF_VARR (htab_ind_t)
                                                                                                  \
     for (size = 2; min_size > size; size *= 2)                                                   \
       ;                                                                                          \
-    ht = malloc (sizeof (*ht));                                                                  \
+    ht = MIR_malloc (alloc, sizeof (*ht));                                                       \
     if (ht == NULL) mir_htab_error ("htab: no memory");                                          \
-    VARR_CREATE (HTAB_EL (T), ht->els, size);                                                    \
+    VARR_CREATE (HTAB_EL (T), ht->els, alloc, size);                                             \
     VARR_TAILOR (HTAB_EL (T), ht->els, size);                                                    \
-    VARR_CREATE (htab_ind_t, ht->entries, 2 * size);                                             \
+    VARR_CREATE (htab_ind_t, ht->entries, alloc, 2 * size);                                      \
     ht->arg = arg;                                                                               \
     ht->hash_func = hash_func;                                                                   \
     ht->eq_func = eq_func;                                                                       \
@@ -133,9 +135,10 @@ DEF_VARR (htab_ind_t)
   static inline void HTAB_OP_DEF (T, destroy) (HTAB (T) * *htab) {                               \
     HTAB_ASSERT (*htab != NULL, "destroy", T);                                                   \
     if ((*htab)->free_func != NULL) HTAB_OP (T, clear) (*htab);                                  \
+    MIR_alloc_t alloc = (*htab)->els->alloc;                                                     \
     VARR_DESTROY (HTAB_EL (T), (*htab)->els);                                                    \
     VARR_DESTROY (htab_ind_t, (*htab)->entries);                                                 \
-    free (*htab);                                                                                \
+    MIR_free (alloc, *htab);                                                                     \
     *htab = NULL;                                                                                \
   }                                                                                              \
                                                                                                  \
@@ -235,9 +238,9 @@ DEF_VARR (htab_ind_t)
       if (els_addr[i].hash != HTAB_DELETED_HASH) func (els_addr[i].el, arg);                     \
   }
 
-#define HTAB_CREATE(T, V, S, H, EQ, A) (HTAB_OP (T, create) (&(V), S, H, EQ, NULL, A))
-#define HTAB_CREATE_WITH_FREE_FUNC(T, V, S, H, EQ, F, A) \
-  (HTAB_OP (T, create) (&(V), S, H, EQ, F, A))
+#define HTAB_CREATE(T, V, M, S, H, EQ, A) (HTAB_OP (T, create) (&(V), M, S, H, EQ, NULL, A))
+#define HTAB_CREATE_WITH_FREE_FUNC(T, V, M, S, H, EQ, F, A) \
+  (HTAB_OP (T, create) (&(V), M, S, H, EQ, F, A))
 #define HTAB_CLEAR(T, V) (HTAB_OP (T, clear) (V))
 #define HTAB_DESTROY(T, V) (HTAB_OP (T, destroy) (&(V)))
 /* It returns TRUE if the element existed in the table.  */

--- a/mir-interp.c
+++ b/mir-interp.c
@@ -4,9 +4,11 @@
    File contains MIR interpreter which is an obligatory part of MIR API.
 */
 
+#include "mir-alloc.h"
+#include "mir.h"
 #ifdef MIR_NO_INTERP
 static void interp_init (MIR_context_t ctx) {}
-static void finish_func_interpretation (MIR_item_t func_item) {}
+static void finish_func_interpretation (MIR_item_t func_item, MIR_alloc_t alloc) {}
 static void interp_finish (MIR_context_t ctx) {}
 void MIR_interp (MIR_context_t ctx, MIR_item_t func_item, MIR_val_t *results, size_t nargs, ...) {}
 void MIR_interp_arr_varg (MIR_context_t ctx, MIR_item_t func_item, MIR_val_t *results, size_t nargs,
@@ -502,7 +504,7 @@ static void generate_icode (MIR_context_t ctx, MIR_item_t func_item) {
     }
   }
   func_item->data = func_desc
-    = malloc (sizeof (struct func_desc) + VARR_LENGTH (MIR_val_t, code_varr) * sizeof (MIR_val_t));
+    = MIR_malloc (ctx->alloc, sizeof (struct func_desc) + VARR_LENGTH (MIR_val_t, code_varr) * sizeof (MIR_val_t));
   if (func_desc == NULL)
     (*MIR_get_error_func (ctx)) (MIR_alloc_error, "no memory for interpreter code");
   memmove (func_desc->code, VARR_ADDR (MIR_val_t, code_varr),
@@ -520,13 +522,13 @@ static void generate_icode (MIR_context_t ctx, MIR_item_t func_item) {
   func_desc->func_item = func_item;
 }
 
-static void finish_func_interpretation (MIR_item_t func_item) {
+static void finish_func_interpretation (MIR_item_t func_item, MIR_alloc_t alloc) {
   mir_assert (func_item->item_type == MIR_func_item);
   if (func_item->data == NULL) return;
   for (MIR_insn_t insn = DLIST_HEAD (MIR_insn_t, func_item->u.func->insns); insn != NULL;
        insn = DLIST_NEXT (MIR_insn_t, insn))
     insn->data = NULL; /* it was used for interpretation preparation */
-  free (func_item->data);
+  MIR_free (alloc, func_item->data);
   func_item->data = NULL;
 }
 
@@ -1732,7 +1734,10 @@ static int ff_interface_eq (ff_interface_t i1, ff_interface_t i2, void *arg MIR_
   return TRUE;
 }
 
-static void ff_interface_clear (ff_interface_t ffi, void *arg MIR_UNUSED) { free (ffi); }
+static void ff_interface_clear (ff_interface_t ffi, void *arg) {
+  MIR_alloc_t alloc = (MIR_alloc_t) arg;
+  MIR_free (alloc, ffi);
+}
 
 static void *get_ff_interface (MIR_context_t ctx, size_t arg_vars_num, size_t nres,
                                MIR_type_t *res_types, size_t nargs, _MIR_arg_desc_t *arg_descs,
@@ -1749,8 +1754,8 @@ static void *get_ff_interface (MIR_context_t ctx, size_t arg_vars_num, size_t nr
   ffi_s.arg_descs = arg_descs;
   if (HTAB_DO (ff_interface_t, ff_interface_tab, &ffi_s, HTAB_FIND, tab_ffi))
     return tab_ffi->interface_addr;
-  ffi = malloc (sizeof (struct ff_interface) + sizeof (_MIR_arg_desc_t) * nargs
-                + sizeof (MIR_type_t) * nres);
+  ffi = MIR_malloc (ctx->alloc, sizeof (struct ff_interface) + sizeof (_MIR_arg_desc_t) * nargs
+                    + sizeof (MIR_type_t) * nres);
   ffi->arg_vars_num = arg_vars_num;
   ffi->nres = nres;
   ffi->nargs = nargs;
@@ -1866,26 +1871,27 @@ static void call (MIR_context_t ctx, MIR_val_t *bp, MIR_op_t *insn_arg_ops, code
 }
 
 static void interp_init (MIR_context_t ctx) {
+  MIR_alloc_t alloc = ctx->alloc;
   struct interp_ctx *interp_ctx;
 
   addr_offset8 = _MIR_addr_offset (ctx, MIR_ADDR8);
   addr_offset16 = _MIR_addr_offset (ctx, MIR_ADDR16);
   addr_offset32 = _MIR_addr_offset (ctx, MIR_ADDR32);
-  if ((interp_ctx = ctx->interp_ctx = malloc (sizeof (struct interp_ctx))) == NULL)
+  if ((interp_ctx = ctx->interp_ctx = MIR_malloc (alloc, sizeof (struct interp_ctx))) == NULL)
     MIR_get_error_func (ctx) (MIR_alloc_error, "Not enough memory for ctx");
 #if DIRECT_THREADED_DISPATCH
   eval (ctx, NULL, NULL, NULL);
 #endif
-  VARR_CREATE (MIR_insn_t, branches, 0);
-  VARR_CREATE (MIR_val_t, code_varr, 0);
-  VARR_CREATE (MIR_val_t, arg_vals_varr, 0);
+  VARR_CREATE (MIR_insn_t, branches, alloc, 0);
+  VARR_CREATE (MIR_val_t, code_varr, alloc, 0);
+  VARR_CREATE (MIR_val_t, arg_vals_varr, alloc, 0);
   arg_vals = VARR_ADDR (MIR_val_t, arg_vals_varr);
-  VARR_CREATE (MIR_val_t, call_res_args_varr, 0);
-  VARR_CREATE (_MIR_arg_desc_t, call_arg_descs_varr, 0);
+  VARR_CREATE (MIR_val_t, call_res_args_varr, alloc, 0);
+  VARR_CREATE (_MIR_arg_desc_t, call_arg_descs_varr, alloc, 0);
   call_res_args = VARR_ADDR (MIR_val_t, call_res_args_varr);
   call_arg_descs = VARR_ADDR (_MIR_arg_desc_t, call_arg_descs_varr);
-  HTAB_CREATE_WITH_FREE_FUNC (ff_interface_t, ff_interface_tab, 1000, ff_interface_hash,
-                              ff_interface_eq, ff_interface_clear, NULL);
+  HTAB_CREATE_WITH_FREE_FUNC (ff_interface_t, ff_interface_tab, alloc, 1000, ff_interface_hash,
+                              ff_interface_eq, ff_interface_clear, alloc);
 #if MIR_INTERP_TRACE
   trace_insn_ident = 0;
 #endif
@@ -1903,7 +1909,7 @@ static void interp_finish (MIR_context_t ctx) {
   VARR_DESTROY (_MIR_arg_desc_t, call_arg_descs_varr);
   HTAB_DESTROY (ff_interface_t, ff_interface_tab);
   /* Clear func descs???  */
-  free (ctx->interp_ctx);
+  MIR_free (ctx->alloc, ctx->interp_ctx);
   ctx->interp_ctx = NULL;
 }
 

--- a/mir-ppc64.c
+++ b/mir-ppc64.c
@@ -3,17 +3,19 @@
 */
 
 #include "mir-ppc64.h"
+#include "mir-alloc.h"
+#include "mir.h"
 
 /* All BLK type values is passed in int regs, and if the regs are not enough, the rest is passed on
    the stack. RBLK is always passed by address.  */
 
 #define VA_LIST_IS_ARRAY_P 1 /* one element which is a pointer to args */
 
-static void ppc64_push_func_desc (VARR (uint8_t) * *insn_varr);
-void (*ppc64_func_desc) (VARR (uint8_t) * *insn_varr) = ppc64_push_func_desc;
+static void ppc64_push_func_desc (MIR_alloc_t alloc, VARR (uint8_t) * *insn_varr);
+void (*ppc64_func_desc) (MIR_alloc_t alloc, VARR (uint8_t) * *insn_varr) = ppc64_push_func_desc;
 
-static void ppc64_push_func_desc (VARR (uint8_t) * *insn_varr) {
-  VARR_CREATE (uint8_t, *insn_varr, 128);
+static void ppc64_push_func_desc (MIR_alloc_t alloc, VARR (uint8_t) * *insn_varr) {
+  VARR_CREATE (uint8_t, *insn_varr, alloc, 128);
   for (int i = 0; i < PPC64_FUNC_DESC_LEN; i++)
     VARR_PUSH (uint8_t, *insn_varr, ((uint8_t *) ppc64_func_desc)[i]);
 }
@@ -118,7 +120,7 @@ void *_MIR_get_bstart_builtin (MIR_context_t ctx) {
   };
   VARR (uint8_t) * code;
 
-  ppc64_push_func_desc (&code);
+  ppc64_push_func_desc (ctx->alloc, &code);
   push_insns (code, bstart_code, sizeof (bstart_code));
   return ppc64_publish_func_and_redirect (ctx, code);
 }
@@ -130,7 +132,7 @@ void *_MIR_get_bend_builtin (MIR_context_t ctx) {
   };
   VARR (uint8_t) * code;
 
-  ppc64_push_func_desc (&code);
+  ppc64_push_func_desc (ctx->alloc, &code);
   ppc64_gen_ld (code, 0, 1, 0, MIR_T_I64);                /* r0 = 0(r1) */
   ppc64_gen_st (code, 0, 3, 0, MIR_T_I64);                /* 0(r3) = r0 */
   ppc64_gen_ld (code, 0, 1, PPC64_TOC_OFFSET, MIR_T_I64); /* r0 = toc_offset(r1) */
@@ -145,7 +147,7 @@ void *_MIR_get_thunk (MIR_context_t ctx) { /* emit 3 doublewords for func descri
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   for (int i = 0; i < max_thunk_len / 4; i++) push_insn (code, TARGET_NOP);
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
   VARR_DESTROY (uint8_t, code);
@@ -159,7 +161,7 @@ static const uint32_t thunk_code_end[] = {
 
 void _MIR_redirect_thunk (MIR_context_t ctx, void *thunk, void *to) {
   VARR (uint8_t) * code;
-  VARR_CREATE (uint8_t, code, 256);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 256);
   ppc64_gen_address (code, 12, to);
   push_insns (code, thunk_code_end, sizeof (thunk_code_end));
   mir_assert ((VARR_LENGTH (uint8_t, code) & 0x3) == 0
@@ -238,7 +240,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
   int disp, blk_disp, param_offset, param_size = 0;
   VARR (uint8_t) * code;
 
-  ppc64_push_func_desc (&code);
+  ppc64_push_func_desc (ctx->alloc, &code);
   for (uint32_t i = 0; i < nargs; i++) {
     type = arg_descs[i].type;
     if (MIR_blk_type_p (type))
@@ -375,7 +377,7 @@ void *_MIR_get_interp_shim (MIR_context_t ctx, MIR_item_t func_item, void *handl
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 256);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 256);
   frame_size = PPC64_STACK_HEADER_SIZE + 64; /* header + 8(param area) */
   local_var_size = nres * 16 + 16;           /* saved r14, r15, results */
   if (vararg_p) {
@@ -508,7 +510,7 @@ void *_MIR_get_bb_thunk (MIR_context_t ctx, void *bb_version, void *handler) {
   size_t offset;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 64);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 64);
   ppc64_gen_address (code, 11, bb_version); /* x11 = bb_version */
   offset = VARR_LENGTH (uint8_t, code);
   for (int i = 0; i < max_thunk_len / 4; i++) push_insn (code, TARGET_NOP);
@@ -538,7 +540,7 @@ void _MIR_replace_bb_thunk (MIR_context_t ctx, void *thunk, void *to) {
   }
   mir_assert (i <= 5);
   offset = i * 4;
-  VARR_CREATE (uint8_t, code, 64);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 64);
   redirect_bb_thunk (ctx, code, (char *) thunk + offset, to);
   VARR_DESTROY (uint8_t, code);
 }
@@ -555,7 +557,7 @@ void *_MIR_get_wrapper (MIR_context_t ctx, MIR_item_t called_func, void *hook_ad
   void *res;
   int frame_size = wrapper_frame_size;
 
-  VARR_CREATE (uint8_t, code, 256);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 256);
   push_insns (code, prologue, sizeof (prologue));
   /* stdu r1,n(r1): header + 8(gp args) + 13(fp args) + 8(param area): */
   if (frame_size % 16 != 0) frame_size += 8;
@@ -588,7 +590,7 @@ void *_MIR_get_wrapper_end (MIR_context_t ctx) {
   int frame_size = wrapper_frame_size;
 
   if (frame_size % 16 != 0) frame_size += 8;
-  VARR_CREATE (uint8_t, code, 256);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 256);
   for (unsigned reg = 5; reg <= 10; reg++) /* std rn,dispn(r1) : */
     ppc64_gen_st (code, reg, 1, PPC64_STACK_HEADER_SIZE + (reg - 3) * 8 + 64, MIR_T_I64);
   for (unsigned reg = 1; reg <= 13; reg++) /* stfd fn,dispn(r1) : */
@@ -631,7 +633,7 @@ void *_MIR_get_bb_wrapper (MIR_context_t ctx, void *data, void *hook_address) {
   void *res;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 256);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 256);
   push_insns (code, prologue, sizeof (prologue));
   /* stdu r1,n(r1): header + 14(gp regs, r{1,2,11} space alloc is not used) + 14(fp args) + 8(param
    * area): */

--- a/mir-reduce.h
+++ b/mir-reduce.h
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <assert.h>
 #include "mir-hash.h"
+#include "mir-alloc.h"
 
 #define FALSE 0
 #define TRUE 1
@@ -286,8 +287,9 @@ static void _reduce_reset_next (struct reduce_data *data) {
 
 #define _REDUCE_CHECK_HASH_SEED 42
 
-static inline struct reduce_data *reduce_encode_start (reduce_writer_t writer, void *aux_data) {
-  struct reduce_data *data = malloc (sizeof (struct reduce_data));
+static inline struct reduce_data *reduce_encode_start (MIR_alloc_t alloc, reduce_writer_t writer,
+                                                       void *aux_data) {
+  struct reduce_data *data = MIR_malloc (alloc, sizeof (struct reduce_data));
   char prefix[] = _REDUCE_DATA_PREFIX;
   size_t prefix_size = strlen (prefix);
 
@@ -333,18 +335,19 @@ static inline void reduce_encode_put (struct reduce_data *data, int c) {
   data->buf[data->buf_bound++] = c;
 }
 
-static inline int reduce_encode_finish (struct reduce_data *data) {
+static inline int reduce_encode_finish (MIR_alloc_t alloc, struct reduce_data *data) {
   int ok_p;
 
   _reduce_encode_buf (data);
   _reduce_hash_write (data, data->check_hash);
   ok_p = data->ok_p;
-  free (data);
+  MIR_free (alloc, data);
   return ok_p;
 }
 
-static inline struct reduce_data *reduce_decode_start (reduce_reader_t reader, void *aux_data) {
-  struct reduce_data *data = malloc (sizeof (struct reduce_data));
+static inline struct reduce_data *reduce_decode_start (MIR_alloc_t alloc, reduce_reader_t reader,
+                                                       void *aux_data) {
+  struct reduce_data *data = MIR_malloc (alloc, sizeof (struct reduce_data));
   struct _reduce_decode_data *decode_data = &data->u.decode;
   char prefix[] = _REDUCE_DATA_PREFIX, str[sizeof (prefix)];
   size_t prefix_size = strlen (prefix);
@@ -421,33 +424,35 @@ static inline int reduce_decode_get (struct reduce_data *data) {
   return -1;
 }
 
-static inline int reduce_decode_finish (struct reduce_data *data) {
+static inline int reduce_decode_finish (MIR_alloc_t alloc, struct reduce_data *data) {
   uint8_t tag;
   int ok_p
     = data->ok_p && data->u.decode.eof_p && data->u.decode.reader (&tag, 1, data->aux_data) == 0;
 
-  free (data);
+  MIR_free (alloc, data);
   return ok_p;
 }
 
 #define _REDUCE_WRITE_IO_LEN 256
-static inline int reduce_encode (reduce_reader_t reader, reduce_writer_t writer, void *aux_data) {
+static inline int reduce_encode (MIR_alloc_t alloc, reduce_reader_t reader, reduce_writer_t writer,
+                                 void *aux_data) {
   size_t i, size;
   uint8_t buf[_REDUCE_WRITE_IO_LEN];
-  struct reduce_data *data = reduce_encode_start (writer, aux_data);
+  struct reduce_data *data = reduce_encode_start (alloc, writer, aux_data);
 
   if (data == NULL) return FALSE;
   for (;;) {
     if ((size = reader (buf, _REDUCE_WRITE_IO_LEN, data->aux_data)) == 0) break;
     for (i = 0; i < size; i++) reduce_encode_put (data, buf[i]);
   }
-  return reduce_encode_finish (data);
+  return reduce_encode_finish (alloc, data);
 }
 
-static inline int reduce_decode (reduce_reader_t reader, reduce_writer_t writer, void *aux_data) {
+static inline int reduce_decode (MIR_alloc_t alloc, reduce_reader_t reader, reduce_writer_t writer,
+                                 void *aux_data) {
   int c, i;
   uint8_t buf[_REDUCE_WRITE_IO_LEN];
-  struct reduce_data *data = reduce_decode_start (reader, aux_data);
+  struct reduce_data *data = reduce_decode_start (alloc, reader, aux_data);
 
   if (data == NULL) return FALSE;
   for (;;) {
@@ -455,7 +460,7 @@ static inline int reduce_decode (reduce_reader_t reader, reduce_writer_t writer,
     if (i != 0) writer (buf, i, aux_data);
     if (c < 0) break;
   }
-  return reduce_decode_finish (data);
+  return reduce_decode_finish (alloc, data);
 }
 
 #endif /* #ifndef MIR_REDUCE_H */

--- a/mir-riscv64.c
+++ b/mir-riscv64.c
@@ -357,7 +357,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   mir_assert (__SIZEOF_LONG_DOUBLE__ == 16);
   for (size_t i = 0; i < nargs; i++) { /* calculate offset for blk params */
     type = arg_descs[i].type;
@@ -590,8 +590,8 @@ void *_MIR_get_interp_shim (MIR_context_t ctx, MIR_item_t func_item, void *handl
   uint32_t pat, n_xregs, n_fregs, parts;
 
   assert (__SIZEOF_LONG_DOUBLE__ == 16);
-  VARR_CREATE (uint8_t, code, 128);
-  VARR_CREATE (uint8_t, code2, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
+  VARR_CREATE (uint8_t, code2, ctx->alloc, 128);
   push_insns (code, &t0_sp, sizeof (t0_sp));           /* t0 = sp */
   push_insns (code, &sub_arg_sp, sizeof (sub_arg_sp)); /* sp -= <sp_offset> */
   sp_offset = 0;
@@ -861,7 +861,7 @@ void *_MIR_get_wrapper (MIR_context_t ctx, MIR_item_t called_func, void *hook_ad
   uint32_t insns[MAX_JUMP_CODE];
   int len = 64; /* initial len */
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   for (;;) { /* dealing with moving code to another page as the immediate call is pc relative */
     base_addr = _MIR_get_new_code_addr (ctx, len);
     if (base_addr == NULL) break;
@@ -914,7 +914,7 @@ void *_MIR_get_wrapper_end (MIR_context_t ctx) {
   uint8_t *res_code;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, &sub_sp, sizeof (sub_sp));
   push_insns (code, &save_ra, sizeof (save_ra));
   push_insns (code, save_insns, sizeof (save_insns));
@@ -1100,7 +1100,7 @@ void *_MIR_get_bb_thunk (MIR_context_t ctx, void *bb_version, void *handler) {
   void *res;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 64);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 64);
   assert (MAX_JUMP_CODE == 6);
   push_insns (code, pat, sizeof (pat));
   for (int i = 0; i < MAX_JUMP_CODE + 2; i++)
@@ -1149,7 +1149,7 @@ void *_MIR_get_bb_wrapper (MIR_context_t ctx, void *data, void *hook_address) {
   size_t args_start, offset;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   VARR_TRUNC (uint8_t, code, 0);
   push_insns (code, &sub_sp, sizeof (sub_sp));
   push_insns (code, &save_ra, sizeof (save_ra));

--- a/mir-s390x.c
+++ b/mir-s390x.c
@@ -137,7 +137,7 @@ void *_MIR_get_bstart_builtin (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   s390x_gen_mov (code, 2, 15);      /* lgr r2,15 */
   s390x_gen_jump (code, 14, FALSE); /* bcr m15,r14 */
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
@@ -149,7 +149,7 @@ void *_MIR_get_bend_builtin (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   s390x_gen_ld (code, 0, 15, 0, MIR_T_I64); /* r0 = 0(r15) */
   s390x_gen_st (code, 0, 2, 0, MIR_T_I64);  /* 0(r2) = r0 */
   s390x_gen_mov (code, 15, 2);              /* lgr r15,2 */
@@ -164,7 +164,7 @@ void *_MIR_get_thunk (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   for (int i = 0; i < max_thunk_len; i++) VARR_PUSH (uint8_t, code, 0);
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
   VARR_DESTROY (uint8_t, code);
@@ -176,7 +176,7 @@ static void redirect_thunk (MIR_context_t ctx, void *thunk, void *to, long temp_
   VARR (uint8_t) * code;
 
   assert (temp_reg != 0);
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   assert (offset % 2 == 0);
   offset /= 2;
   if (-(1l << 31) < offset && offset < (1l << 31)) { /* brcl m15,offset: */
@@ -283,7 +283,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   blk_offset = frame_size = S390X_STACK_HEADER_SIZE;
   if (nres > 0 && res_types[0] == MIR_T_LD) n_gpregs++; /* ld address */
   for (uint32_t i = 0; i < nargs; i++) {                /* calculate param area size: */
@@ -397,7 +397,7 @@ void *_MIR_get_interp_shim (MIR_context_t ctx, MIR_item_t func_item, void *handl
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   frame_size = S390X_STACK_HEADER_SIZE;        /* register save area */
   s390x_gen_st (code, 14, 15, 112, MIR_T_I64); /* stg 14,112(r15) */
   s390x_gen_ldstm (code, 2, 6, 15, 16, FALSE); /* stmg 2,6,16(r15) : */
@@ -472,7 +472,7 @@ void *_MIR_get_wrapper (MIR_context_t ctx, MIR_item_t called_func, void *hook_ad
   uint16_t lr = (0x18 << 8);                 /* lr r0,r0 */
   uint16_t balr = (0x5 << 8) | (1 << 4) | 1; /* balr r1,r1: */
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, (uint8_t *) &lalr, 6);
   push_insns (code, (uint8_t *) &lr, 2);
   s390x_gen_ld (code, 1, 1, 24, MIR_T_I64); /* lg r1,24(r1) */
@@ -497,7 +497,7 @@ void *_MIR_get_wrapper_end (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   s390x_gen_st (code, 14, 15, 112, MIR_T_I64); /* stg 14,112(r15) */
   s390x_gen_ldstm (code, 2, 6, 15, 16, FALSE); /* stmg 2,6,16(r15) : */
   for (unsigned reg = 0; reg <= 6; reg += 2)   /* stdy f0,f2,f4,f6,128(r15) : */
@@ -533,7 +533,7 @@ void *_MIR_get_bb_thunk (MIR_context_t ctx, void *bb_version, void *handler) {
   uint64_t lg = ((0xe3l << 40) | (0l << 36) | (1l << 28) | 0x4) << 16;
   uint32_t nop = (0x47 << 24);
 
-  VARR_CREATE (uint8_t, code, 64);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 64);
   /* 6b:lalr r1,8; 6b:lg r0,0(r1); 4b: nop for padding; */
   push_insns (code, (uint8_t *) &lalr, 6);
   push_insns (code, (uint8_t *) &lg, 6);
@@ -563,7 +563,7 @@ void *_MIR_get_bb_wrapper (MIR_context_t ctx, void *data, void *hook_address) {
   void *res;
   VARR (uint8_t) * code;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   /* saving regs which can be put reg save area: */
   s390x_gen_ldstm (code, 2, 6, 15, 16, FALSE); /* stmg 2,6,16(r15) : */
   s390x_gen_st (code, 14, 15, 112, MIR_T_I64); /* ???do we need this: stg 14,112(r15) */

--- a/mir-utils/m2b.c
+++ b/mir-utils/m2b.c
@@ -1,6 +1,7 @@
 /* Transform mir textual form from stdin into mir binary to
    stdout.  */
 
+#include "mir-alloc.h"
 #include "mir.h"
 
 #ifdef _WIN32
@@ -16,6 +17,7 @@ DEF_VARR (char);
 
 int main (int argc, char *argv[]) {
   MIR_context_t ctx = MIR_init ();
+  MIR_alloc_t alloc = MIR_get_alloc (ctx);
   VARR (char) * str;
   int c;
 
@@ -24,7 +26,7 @@ int main (int argc, char *argv[]) {
     fprintf (stderr, "Usage: %s < mir-text-file > mir-binary-file\n", argv[1]);
     return 1;
   }
-  VARR_CREATE (char, str, 1024 * 1024);
+  VARR_CREATE (char, str, alloc, 1024 * 1024);
   while ((c = getchar ()) != EOF) VARR_PUSH (char, str, c);
   VARR_PUSH (char, str, 0);
   MIR_scan_string (ctx, VARR_ADDR (char, str));

--- a/mir-varr.h
+++ b/mir-varr.h
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include "mir-alloc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,6 +61,7 @@ static inline void MIR_VARR_NO_RETURN mir_varr_error (const char *message) {
     size_t els_num;         \
     size_t size;            \
     T *varr;                \
+    MIR_alloc_t alloc;      \
   } VARR (T)
 
 #define VARR_DEFAULT_SIZE 64
@@ -68,21 +70,24 @@ static inline void MIR_VARR_NO_RETURN mir_varr_error (const char *message) {
 #define DEF_VARR(T)                                                                           \
   VARR_T (T);                                                                                 \
                                                                                               \
-  static inline void VARR_OP_DEF (T, create) (VARR (T) * *varr, size_t size) {                \
+  static inline void VARR_OP_DEF (T, create) (VARR (T) * *varr, MIR_alloc_t alloc,            \
+                                              size_t size) {                                  \
     VARR (T) * va;                                                                            \
     if (size == 0) size = VARR_DEFAULT_SIZE;                                                  \
-    *varr = va = (VARR (T) *) malloc (sizeof (VARR (T)));                                     \
+    *varr = va = (VARR (T) *) MIR_malloc (alloc, sizeof (VARR (T)));                          \
     if (va == NULL) mir_varr_error ("varr: no memory");                                       \
     va->els_num = 0;                                                                          \
     va->size = size;                                                                          \
-    va->varr = (T *) malloc (size * sizeof (T));                                              \
+    va->varr = (T *) MIR_malloc (alloc, size * sizeof (T));                                   \
+    va->alloc = alloc;                                                                        \
   }                                                                                           \
                                                                                               \
   static inline void VARR_OP_DEF (T, destroy) (VARR (T) * *varr) {                            \
     VARR (T) *va = *varr;                                                                     \
+    MIR_alloc_t alloc = va->alloc;                                                            \
     VARR_ASSERT (va && va->varr, "destroy", T);                                               \
-    free (va->varr);                                                                          \
-    free (va);                                                                                \
+    MIR_free (alloc, va->varr);                                                               \
+    MIR_free (alloc, va);                                                                     \
     *varr = NULL;                                                                             \
   }                                                                                           \
                                                                                               \
@@ -123,9 +128,11 @@ static inline void MIR_VARR_NO_RETURN mir_varr_error (const char *message) {
                                                                                               \
   static inline int VARR_OP_DEF (T, expand) (VARR (T) * varr, size_t size) {                  \
     VARR_ASSERT (varr && varr->varr, "expand", T);                                            \
+    MIR_alloc_t alloc = varr->alloc;                                                          \
     if (varr->size < size) {                                                                  \
       size += size / 2;                                                                       \
-      varr->varr = (T *) realloc (varr->varr, sizeof (T) * size);                             \
+      varr->varr = (T *) MIR_realloc (alloc, varr->varr, sizeof (T) * varr->size,             \
+                                      sizeof (T) * size);                                     \
       varr->size = size;                                                                      \
       return 1;                                                                               \
     }                                                                                         \
@@ -134,7 +141,10 @@ static inline void MIR_VARR_NO_RETURN mir_varr_error (const char *message) {
                                                                                               \
   static inline void VARR_OP_DEF (T, tailor) (VARR (T) * varr, size_t size) {                 \
     VARR_ASSERT (varr && varr->varr, "tailor", T);                                            \
-    if (varr->size != size) varr->varr = (T *) realloc (varr->varr, sizeof (T) * size);       \
+    MIR_alloc_t alloc = varr->alloc;                                                          \
+    if (varr->size != size)                                                                   \
+      varr->varr = (T *) MIR_realloc (alloc, varr->varr, sizeof (T) * varr->size,             \
+                                      sizeof (T) * size);                                     \
     varr->els_num = varr->size = size;                                                        \
   }                                                                                           \
                                                                                               \
@@ -162,7 +172,7 @@ static inline void MIR_VARR_NO_RETURN mir_varr_error (const char *message) {
     return obj;                                                                               \
   }
 
-#define VARR_CREATE(T, V, L) (VARR_OP (T, create) (&(V), L))
+#define VARR_CREATE(T, V, A, L) (VARR_OP (T, create) (&(V), A, L))
 #define VARR_DESTROY(T, V) (VARR_OP (T, destroy) (&(V)))
 #define VARR_LENGTH(T, V) (VARR_OP (T, length) (V))
 #define VARR_CAPACITY(T, V) (VARR_OP (T, capacity) (V))

--- a/mir-x86_64.c
+++ b/mir-x86_64.c
@@ -429,7 +429,7 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, prolog, sizeof (prolog));
   for (size_t i = 0; i < nargs; i++) {
     MIR_type_t type = arg_descs[i].type;
@@ -641,7 +641,7 @@ void *_MIR_get_interp_shim (MIR_context_t ctx, MIR_item_t func_item, void *handl
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
 #ifndef _WIN32
   push_insns (code, push_rbx, sizeof (push_rbx));
 #endif
@@ -726,7 +726,7 @@ void *_MIR_get_wrapper (MIR_context_t ctx, MIR_item_t called_func, void *hook_ad
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   addr = push_insns (code, start_pat, sizeof (start_pat));
   memcpy (addr + call_func_offset, &called_func, sizeof (void *));
   memcpy (addr + ctx_offset, &ctx, sizeof (void *));
@@ -816,7 +816,7 @@ void *_MIR_get_wrapper_end (MIR_context_t ctx) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, wrap_end, sizeof (wrap_end));
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
   VARR_DESTROY (uint8_t, code);
@@ -959,7 +959,7 @@ void *_MIR_get_bb_wrapper (MIR_context_t ctx, void *data, void *hook_address) {
   VARR (uint8_t) * code;
   void *res;
 
-  VARR_CREATE (uint8_t, code, 128);
+  VARR_CREATE (uint8_t, code, ctx->alloc, 128);
   push_insns (code, save_pat2, sizeof (save_pat2));
   addr = push_insns (code, call_pat, sizeof (call_pat));
   memcpy (addr + data_offset, &data, sizeof (void *));

--- a/mir2c/mir2c.c
+++ b/mir2c/mir2c.c
@@ -862,6 +862,7 @@ int main (int argc, const char *argv[]) {
   VARR (char) * input;
   MIR_module_t m;
   MIR_context_t ctx = MIR_init ();
+  MIR_alloc_t alloc = MIR_get_alloc (ctx);
 
   if (argc == 1)
     f = stdin;
@@ -874,7 +875,7 @@ int main (int argc, const char *argv[]) {
     fprintf (stderr, "usage: %s < file or %s mir-file\n", argv[0], argv[0]);
     exit (1);
   }
-  VARR_CREATE (char, input, 0);
+  VARR_CREATE (char, input, alloc, 0);
   while ((c = getc (f)) != EOF) VARR_PUSH (char, input, c);
   VARR_PUSH (char, input, 0);
   if (ferror (f)) {


### PR DESCRIPTION
## Overview

Addresses the proposal in #372.
It indeed was took a while until I got around to implement it and this change turned out to be more involved than I expected...

## Disclaimer

I am mainly a C++ developer and only rarely write pure C. I tried to stick to the coding style / naming conventions / etc. used throughout MIR but I might have missed some things. You have been warned :-)

## Implementation

The general purpose memory management routines (`malloc`, `calloc`, `realloc`, `free`) are bundled in struct `MIR_alloc`, which is just a collection of function pointers and some user data. Similarly, function pointers to executable code related memory management functions (`mem_map`, `mem_unmap`, `mem_protect`) are bundled in `MIR_code_alloc`.

Users wanting to provide custom allocators can do so by calling newly introduced function `MIR_init2` (name to be discussed), which takes pointers to both a `MIR_alloc` and a `MIR_code_alloc`. Both can be `NULL`, which results in a default implementation being used. Both pointers are persisted in the `MIR_context` (fields `alloc` and `code_alloc`) for easy consumption by other functions.

The following convenience functions are provided to work with allocators and replace the "raw" functions of corresponding name:
- `void *MIR_malloc (MIR_alloc_t alloc, size_t size)`
- `void *MIR_calloc (MIR_alloc_t alloc, size_t num, size_t size)`
- `void *MIR_realloc (MIR_alloc_t alloc, void *ptr, size_t old_size, size_t new_size)` (a little different than plain `realloc`, see next section)
- `void MIR_free (MIR_alloc_t alloc, void *ptr)`

Similarly, for the executable code management functions:
- `void *MIR_mem_map (MIR_code_alloc_t code_alloc, size_t len)`
- `int MIR_mem_unmap (MIR_code_alloc_t code_alloc, void *ptr, size_t len)`
- `int MIR_mem_protect (MIR_code_alloc_t code_alloc, void *ptr, size_t len, MIR_mem_protect_t prot)`

I initially planned to only feed `MIR_alloc` into the `MIR_context` and feed `MIR_code_alloc` instead into `MIR_gen_init`, but this turned out to be impossible without yet more involved refactorings.

As it currently stands, the core API (exposed by `mir.h`, `mir-gen.h`, etc.) did not change, i.e. existing projects should compile and run just like before without requiring any changes. Internal APIs (like `mir-varr.h`, `mir-htab.h`, etc.) did however change, though I tried to keep these to a minimum. More on this in the next section.

## Potentially Controversial Design Decision

### `VARR`s keep a pointer to their allocator

Both `VARR`s and `HTAB`s (as well as bitmaps) now require passing an allocator when calling their create functions. I wanted to avoid also passing allocators when invoking other operations that might need to manage memory (push, expand, destroy, ...), as this would have severly cluttered the API.

Instead, I opted for `VARR`s storing an additional pointer to the allocator which was passed in when creating them, which are then used for further operations. Slightly increases their memory footprint though.

### `realloc` takes the previous size as an additional parameter

Alternative title: C's and C++'s allocation APIs are not friends.

As I mentioned initially, I come from a C++ background. When designing the allocator interface for MIR, I tried to do it in a way that would also play somewhat nicely with what C++ has to offer. Sadly, what C++ has to offer is less than spectacular: `std::allocator` is a complete mess and its intended replacement `std::pmr::polymorphic_allocator` / `std::pmr::memory_resource` shares some of its quirks:

- Both do not support a `realloc`-style operation
- Both require users to pass the size of the allocation when calling `deallocate`

To support as wide as a range of allocators as possible without complicating the API too much, I opted for the following compromise:

- `MIR_realloc` takes the previous size as an additional parameter. This allows allocator implementations to translate calls to `MIR_realloc` into a `allocate` - `memcpy` - `free` sequence. As `MIR_realloc` is only called inside `mir-varr.h`, required changes on MIR's part were minimal.
- `MIR_free` on the other hand does not take the previous size. This would have required a lot of changes on MIR's part as there are a decent amount of allocations whose size is dynamically determined at runtime. Users wishing to use an API requiring this would need to do their own bookkeeping.

Of course, we could always go more into one or the other direction and:

- go with a fully C-style allocation interface, removing the quirks of `MIR_realloc`
- go with a fully C++-style allocation interface and only provide `MIR_alloc` / `MIR_free`, requiring `VARR` to always copy manually upon expansion
- or something other in between... Ah the choices :-)
 
## Documentation

I added some documentation, both for users of MIR as a library as well as developers of MIR, in `CUSTOM-ALLOCATORS.md`.

## Testing

This is partly covered by the existing tests, though it may be nice to add some allocator specific ones. While it would be pretty straightforward to test that a given allocator has been called, the other way around (ensuring that `malloc`, `free`, etc. are not called when a custom allocator is passed) is a bit harder. Not sure if there is some cross platform magic to override `malloc` and the others...

## Things I am unsure about

- **Thread safety:** As far as I can tell, users supplying custom allocators wishing to call MIR from multiple threads simply need to ensure their supplied functions are thread safe.

## Conclusion

I hope this fits MIR and my ramblings did not scare you away already :-)
Let me know if there are things that need improvement / polish.