### PR TITLE
Fix build failures introduced by custom allocators

### DIFF
--- a/llvm2mir/llvm2mir-driver.c
+++ b/llvm2mir/llvm2mir-driver.c
@@ -167,10 +167,10 @@ int main (int argc, char *argv[], char *env[]) {
                 (MIR_val_t){.a = (void *) env});
     res = val.i;
   } else if (gen_p) {
-    MIR_gen_init (context, 1);
-    if (gen_debug_p) MIR_gen_set_debug_file (context, 0, stderr);
+    MIR_gen_init (context);
+    if (gen_debug_p) MIR_gen_set_debug_file (context, stderr);
     MIR_link (context, MIR_set_gen_interface, import_resolver);
-    fun_addr = MIR_gen (context, 0, main_func);
+    fun_addr = MIR_gen (context, main_func);
     res = fun_addr (argc, argv, env);
     MIR_gen_finish (context);
   }

--- a/mir-alloc.h
+++ b/mir-alloc.h
@@ -6,6 +6,7 @@
 #define MIR_ALLOC_H
 
 #include <assert.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/mir-bin-run.c
+++ b/mir-bin-run.c
@@ -6,6 +6,8 @@
 #include <sys/stat.h>
 #include "mir-gen.h"  // mir.h gets included as well
 
+#include "mir-alloc-default.c"
+
 #define MIR_TYPE_INTERP 1
 #define MIR_TYPE_INTERP_NAME "interp"
 #define MIR_TYPE_GEN 2
@@ -292,9 +294,9 @@ int main (int argc, char **argv, char **envp) {
   MIR_val_t val;
   int exit_code;
 
-  VARR_CREATE (char, temp_string, 0);
-  VARR_CREATE (lib_t, extra_libs, 16);
-  VARR_CREATE (char_ptr_t, lib_dirs, 16);
+  VARR_CREATE (char, temp_string, &default_alloc, 0);
+  VARR_CREATE (lib_t, extra_libs, &default_alloc, 16);
+  VARR_CREATE (char_ptr_t, lib_dirs, &default_alloc, 16);
   for (int i = 0; i < sizeof (std_lib_dirs) / sizeof (char_ptr_t); i++)
     VARR_PUSH (char_ptr_t, lib_dirs, std_lib_dirs[i]);
   lib_dirs_from_env_var ("LD_LIBRARY_PATH");


### PR DESCRIPTION
This includes llvm2mir which does not seem to have been built on my Windows machine, as well as some missing includes that became apparent on Linux. Sorry for missing these, building only on Windows was not the best idea!

When running the tests on my Linux machine, unlike on Windows, `gen-test11` is failing due to an assert in `mir-gen.c:7969`: `n == 2`. I cannot directly see a connection to my change however...

Edit: can confirm, `gen-test11` fails on my Linux machine even on d6dffefccb00a51010f8bc9a6e4e871a1a61bc41 (before the allocator commit).