### PR TITLE
Fix null ptr deref in case of MIR_vararg_func_error

### DIFF
--- a/mir.c
+++ b/mir.c
@@ -1591,12 +1591,13 @@ void MIR_finish_func (MIR_context_t ctx) {
       MIR_get_error_func (ctx) (MIR_vararg_func_error, "func %s: mix of RET and JRET insns",
                                 func_name);
     } else if (code == MIR_RET && actual_nops != curr_func->nres) {
+      uint32_t cf_nres = curr_func->nres;
       curr_func = NULL;
       MIR_get_error_func (
         ctx) (MIR_vararg_func_error,
               "func %s: in instruction '%s': number of operands in return does not "
               "correspond number of function returns. Expected %d, got %d",
-              func_name, insn_descs[code].name, curr_func->nres, actual_nops);
+              func_name, insn_descs[code].name, cf_nres, actual_nops);
     } else if (MIR_call_code_p (code)) {
       expr_p = FALSE;
     } else if (code == MIR_BO || code == MIR_UBO || code == MIR_BNO || code == MIR_UBNO) {


### PR DESCRIPTION
curr_func is NULL'd before calling error_func, so save curr_func->nres for the error message first.