### PR TITLE
Fix two RA bugs breaking computed goto (laddr/jmpi) under the generator

### DIFF
--- a/mir-gen.c
+++ b/mir-gen.c
@@ -214,6 +214,8 @@ struct gen_ctx {
 #endif
   VARR (void_ptr_t) * to_free;
   int addr_insn_p;    /* true if we have address insns in the input func */
+  int jmpi_p;         /* true if the input func has indirect jumps (JMPI):
+                         their successor edges cannot be split */
   bitmap_t tied_regs; /* regs tied to hard reg */
   bitmap_t addr_regs; /* regs in addr insns as 2nd op */
   bitmap_t insn_to_consider, temp_bitmap, temp_bitmap2, temp_bitmap3;
@@ -254,6 +256,7 @@ struct gen_ctx {
 #define debug_level gen_ctx->debug_level
 #define to_free gen_ctx->to_free
 #define addr_insn_p gen_ctx->addr_insn_p
+#define jmpi_p gen_ctx->jmpi_p
 #define tied_regs gen_ctx->tied_regs
 #define addr_regs gen_ctx->addr_regs
 #define insn_to_consider gen_ctx->insn_to_consider
@@ -1585,6 +1588,7 @@ static void build_func_cfg (gen_ctx_t gen_ctx) {
   curr_cfg->max_var = MAX_HARD_REG;
   curr_cfg->root_loop_node = NULL;
   curr_bb_index = 0;
+  jmpi_p = FALSE;
   for (i = 0; i < VARR_LENGTH (MIR_var_t, func->vars); i++) {
     mir_var = VARR_GET (MIR_var_t, func->vars, i);
     update_max_var (gen_ctx, MIR_reg (ctx, mir_var.name, func) + MAX_HARD_REG);
@@ -1803,6 +1807,7 @@ static void build_func_cfg (gen_ctx_t gen_ctx) {
       VARR_PUSH (MIR_insn_t, temp_insns2, insn->ops[1].u.label);
     } else if (insn->code == MIR_JMPI) {
       VARR_PUSH (MIR_insn_t, temp_insns, insn);
+      jmpi_p = TRUE;
     }
     nops = MIR_insn_nops (ctx, insn);
     if (next_insn != NULL
@@ -7563,7 +7568,7 @@ static void assign (gen_ctx_t gen_ctx) {
   MIR_func_t func = curr_func_item->u.func;
   bitmap_t global_hard_regs = _MIR_get_module_global_var_hard_regs (ctx, curr_func_item->module);
   const char *msg;
-  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2;
+  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2 || jmpi_p;
   bitmap_t conflict_locs = conflict_locs1, spill_lr_starts = temp_bitmap2;
 
   func_stack_slots_num = 0;
@@ -7608,11 +7613,13 @@ static void assign (gen_ctx_t gen_ctx) {
     bm = bitmap_create2 (alloc, MAX_HARD_REG + 1);
     if (global_hard_regs != NULL) bitmap_copy (bm, global_hard_regs);
     VARR_PUSH (bitmap_t, used_locs, bm);
-    if (!simplified_p) {
-      bm = bitmap_create2 (alloc, MAX_HARD_REG + 1);
-      if (global_hard_regs != NULL) bitmap_copy (bm, global_hard_regs);
-      VARR_PUSH (bitmap_t, busy_used_locs, bm);
-    }
+    /* Keep busy_used_locs in sync with used_locs even for the simplified
+       RA: simplified_p can vary per function (e.g. functions with
+       indirect jumps), and a later function using the full RA clears
+       busy_used_locs entries up to the shared used_locs length. */
+    bm = bitmap_create2 (alloc, MAX_HARD_REG + 1);
+    if (global_hard_regs != NULL) bitmap_copy (bm, global_hard_regs);
+    VARR_PUSH (bitmap_t, busy_used_locs, bm);
   }
   nregs = (int) VARR_LENGTH (allocno_info_t, sorted_regs);
   qsort (VARR_ADDR (allocno_info_t, sorted_regs), nregs, sizeof (allocno_info_t),
@@ -8223,7 +8230,7 @@ static void rewrite (gen_ctx_t gen_ctx) {
   size_t insns_num = 0, movs_num = 0, deleted_movs_num = 0;
   bitmap_t global_hard_regs
     = _MIR_get_module_global_var_hard_regs (gen_ctx->ctx, curr_func_item->module);
-  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2;
+  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2 || jmpi_p;
 
   if (simplified_p) {
     for (insn = DLIST_HEAD (MIR_insn_t, curr_func_item->u.func->insns); insn != NULL;
@@ -8519,7 +8526,7 @@ static void split (gen_ctx_t gen_ctx) { /* split by putting spill/restore insns 
 
 static void reg_alloc (gen_ctx_t gen_ctx) {
   MIR_reg_t reg, max_var = get_max_var (gen_ctx);
-  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2;
+  const int simplified_p = ONLY_SIMPLIFIED_RA || optimize_level < 2 || jmpi_p;
 
   build_live_ranges (gen_ctx);
   assign (gen_ctx);

--- a/mir.c
+++ b/mir.c
@@ -313,7 +313,7 @@ static const struct insn_desc insn_descs[] = {
   {MIR_UBO, "ubo", {MIR_OP_LABEL, MIR_OP_BOUND}},
   {MIR_BNO, "bno", {MIR_OP_LABEL, MIR_OP_BOUND}},
   {MIR_UBNO, "ubno", {MIR_OP_LABEL, MIR_OP_BOUND}},
-  {MIR_LADDR, "laddr", {MIR_OP_INT, MIR_OP_LABEL, MIR_OP_BOUND}},
+  {MIR_LADDR, "laddr", {MIR_OP_INT | OUT_FLAG, MIR_OP_LABEL, MIR_OP_BOUND}},
   {MIR_JMPI, "jmpi", {MIR_OP_INT, MIR_OP_BOUND}},
   {MIR_CALL, "call", {MIR_OP_BOUND}},
   {MIR_INLINE, "inline", {MIR_OP_BOUND}},


### PR DESCRIPTION
Two register-allocator bugs that together break computed goto (`laddr`/`jmpi`) under the generator at `-O2`/`-O3`. Both manifest only under register pressure / NDEBUG, so small examples pass; the reproducer below crashes (or silently misexecutes) on x86-64 and aarch64 Linux at current master.

## Bug 1: `MIR_LADDR`'s destination is not marked as an output

`insn_descs[MIR_LADDR]` lacked `OUT_FLAG` on the first operand, so `MIR_insn_op_mode` reports it as an input. The register allocator (and any other consumer of `out_p`) then treats the laddr destination as a *use*: under pressure it emits a reload before the laddr and omits the spill after it, losing the loaded label address. A subsequent `jmpi` jumps through stale spill-slot memory and crashes.

Fix: one line in `mir.c` — mark the operand `MIR_OP_INT | OUT_FLAG`, like the other address/result-producing insns.

## Bug 2: edge splitting assumes block exits are direct branches

The full RA places spill/restore code on edges and splits critical edges as needed, but an edge out of a `jmpi` block cannot be split — the jump target is computed at run time. `split_edge_if_necessary` assumed the source block ends in a direct branch and overwrote `jmpi`'s **register operand with a label operand**. In debug builds this aborts later with `Fatal failure in matching insn: jmpi L...`; in NDEBUG builds it silently turns an N-way indirect jump into an unconditional jump (we observed a C `switch`-in-loop lowered via computed goto becoming an infinite loop).

Fix: functions containing `MIR_JMPI` use the simplified RA (same path as `ONLY_SIMPLIFIED_RA` / optimization levels below 2), which places spills in blocks rather than on edges. Since RA mode now varies per function within one context, `busy_used_locs` is kept allocated in sync with `used_locs` (a later full-RA function indexes it by the shared `used_locs` length).

I deliberately did **not** add a `jmpi label` machine pattern to paper over the substitution: after the fix it can no longer occur, and the loud matching failure is a useful safety net against invalid future substitutions.

## Reproducer

Three `laddr` → store/load through an alloca slot → `jmpi` sequences with calls in between (to create pressure). Correct output is `1 2 3`, exit 0.

```
./m2b < jmpi-crash.mir > t.bmir
MIR_TYPE=interp ./mir-bin-run t.bmir   # 1 2 3 (correct)
MIR_TYPE=gen    ./mir-bin-run t.bmir   # SIGSEGV before this PR
```

<details><summary>jmpi-crash.mir</summary>

```
dg:	module
	import	printf
fmt:	string	"%d\n\000"
p0:	proto	i32, i64:a0, i32:a1
p1:	proto	i32, i32:a0
chk:	func	i32, i32:A0
	local	i64:r, i64:f
	mov	f, fmt
	call	p0, printf, r, f, A0
	ret	r
	endfunc
	export	main
main:	func	i32
	local	i64:r2
	local	i64:T0, i64:T1, i64:T2, i64:T3, i64:T4, i64:T5
	local	i64:a, i64:b, i64:c, i64:v, i64:w, i64:x, i64:t
	alloca	T0, 16
	alloca	T1, 16
	alloca	T2, 16
	alloca	T3, 16
	alloca	T4, 16
	alloca	T5, 16
	laddr	a, L1
	mov	i64:(T0), a
	mov	i32:(T1), 0
	mov	v, i64:(T0)
	jmpi	v
L1:
	mov	t, i32:(T1)
	adds	t, t, 1
	mov	i32:(T1), t
	call	p1, chk, r2, t
	laddr	b, L2
	mov	i64:(T2), b
	mov	i32:(T3), 0
	mov	w, i64:(T2)
	jmpi	w
L2:
	mov	t, i32:(T3)
	adds	t, t, 2
	mov	i32:(T3), t
	call	p1, chk, r2, t
	laddr	c, L3
	mov	i64:(T4), c
	mov	i32:(T5), 0
	mov	x, i64:(T4)
	jmpi	x
L3:
	mov	t, i32:(T5)
	adds	t, t, 3
	mov	i32:(T5), t
	call	p1, chk, r2, t
	mov	t, 0
	ret	t
	endfunc
	endmodule
```
</details>

## Validation

- `make test` fully green with both fixes on x86-64 Linux (gcc 14) and aarch64 Linux (gcc 13, Graviton).
  (Unrelated observation from that run: `c-tests` `20020413-1`, `20030914-1`, `regstack-1` fail in the `use-c2m-gen-bb` mode on aarch64 at current master *without* these patches — pre-existing, long-double related, x86-64 passes. Happy to file separately.)
- Downstream, these fixes take a C compiler frontend targeting MIR (computed goto, `defer` lowering) from crashing/looping to passing its full test suite under `MIR_gen` at optimization level 2.

Possibly related: #424 (label-address use-after-free class, lref flavor), #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
