### PR TITLE
Fix GVN losing sign/zero extension when forwarding stores to narrower reloads

### DIFF
--- a/c-tests/mir/issue423.mir
+++ b/c-tests/mir/issue423.mir
@@ -1,0 +1,42 @@
+M0:	module
+# GVN forwarded a store's raw 64-bit register to a narrower typed reload,
+# losing the load's sign/zero extension (issue #423).
+f:	func	i64, i64:t, i64:v
+	local	i64:r
+	mov	i32:0(t), v
+	mov	r, i32:0(t)
+	ret	r
+	endfunc
+fu:	func	i64, i64:t, i64:v
+	local	i64:r
+	mov	u32:0(t), v
+	mov	r, u32:0(t)
+	ret	r
+	endfunc
+fb:	func	i64, i64:t, i64:v
+	local	i64:r
+	mov	i8:0(t), v
+	mov	r, i8:0(t)
+	ret	r
+	endfunc
+p:	proto	i64, i64:t, i64:v
+main:	func	i32
+	local	i64:buf, i64:r, i64:fa
+	alloca	buf, 16
+# v = 0x00000000fffffe95: i32 reload must sign-extend to -363
+	mov	fa, f
+	call	p, fa, r, buf, 4294966933
+	bne	fail, r, -363
+# v = 0xfffffffffffffe95: u32 reload must zero-extend to 4294966933
+	mov	fa, fu
+	call	p, fa, r, buf, -363
+	bne	fail, r, 4294966933
+# v = 0x0000000000000095: i8 reload must sign-extend to -107
+	mov	fa, fb
+	call	p, fa, r, buf, 149
+	bne	fail, r, -107
+	ret	0
+fail:	ret	1
+	endfunc
+	export	main
+	endmodule

--- a/mir-gen.c
+++ b/mir-gen.c
@@ -4680,20 +4680,35 @@ static void gvn_modify (gen_ctx_t gen_ctx) {
                 || (mem_insn->ops[1].mode == MIR_OP_VAR_MEM && mem_insn->ops[0].data == NULL)) {
               add_mem_insn (gen_ctx, insn);
             } else { /* (mem=x|x=mem); ...; r=mem => (mem=x|x=mem); t=x; ...; r=t */
-              copy_gvn_info (bb_insn, mem_bb_insn);
-              print_bb_insn_value (gen_ctx, bb_insn);
+              /* When forwarding from a store of an integer type narrower than
+                 64 bits, the loaded value is the stored register *extended*
+                 from the memory type, not the raw stored register: materialize
+                 the temp with the corresponding extension insn (issue #423).  */
+              MIR_insn_code_t temp_code = insn->code;
+              if (op_ref == &mem_insn->ops[0] && insn->code == MIR_MOV) {
+                switch (op_ref->u.var_mem.type) {
+                case MIR_T_I8: temp_code = MIR_EXT8; break;
+                case MIR_T_U8: temp_code = MIR_UEXT8; break;
+                case MIR_T_I16: temp_code = MIR_EXT16; break;
+                case MIR_T_U16: temp_code = MIR_UEXT16; break;
+                case MIR_T_I32: temp_code = MIR_EXT32; break;
+                case MIR_T_U32: temp_code = MIR_UEXT32; break;
+                default: break;
+                }
+              }
               temp_reg = mem_expr->temp_reg;
               add_def_p = temp_reg == MIR_NON_VAR;
               if (add_def_p) {
                 mem_expr->temp_reg = temp_reg
                   = get_expr_temp_reg (gen_ctx, mem_expr->insn, &mem_expr->temp_reg);
-                new_insn = MIR_new_insn (ctx, insn->code, _MIR_new_var_op (ctx, temp_reg),
+                new_insn = MIR_new_insn (ctx, temp_code, _MIR_new_var_op (ctx, temp_reg),
                                          op_ref == &mem_insn->ops[0] ? mem_insn->ops[1]
                                                                      : mem_insn->ops[0]);
                 new_insn->ops[1].data = NULL; /* remove ssa edge taken from load/store op */
                 gen_add_insn_after (gen_ctx, mem_insn, new_insn);
                 new_bb_insn = new_insn->data;
-                copy_gvn_info (new_bb_insn, mem_bb_insn);
+                if (temp_code == insn->code) /* an extended value is a new value: */
+                  copy_gvn_info (new_bb_insn, mem_bb_insn); /* otherwise keep its fresh one */
                 se = op_ref == &mem_insn->ops[0] ? mem_insn->ops[1].data : mem_insn->ops[0].data;
                 add_ssa_edge (gen_ctx, se->def, se->def_op_num, new_bb_insn, 1);
                 DEBUG (2, {
@@ -4709,6 +4724,8 @@ static void gvn_modify (gen_ctx_t gen_ctx) {
               insn->ops[1] = _MIR_new_var_op (ctx, temp_reg); /* changing mem */
               def_insn = DLIST_NEXT (MIR_insn_t, mem_insn);
               add_ssa_edge (gen_ctx, def_insn->data, 0, bb_insn, 1);
+              copy_gvn_info (bb_insn, (bb_insn_t) def_insn->data);
+              print_bb_insn_value (gen_ctx, bb_insn);
               gvn_insns_num++;
               DEBUG (2, {
                 fprintf (debug_file, "  changing curr insn to ");


### PR DESCRIPTION
Fixes #423.

GVN's redundant-load elimination (`(mem=x|x=mem); ...; r=mem  =>  t=x; ...; r=t`) forwarded the raw stored register to the reload. For an integer memory type narrower than 64 bits this is wrong: the load yields the stored value *extended* from the memory type, while the stored register's upper bits can be anything. The minimized case from #423:

```c
int64_t foo (int32_t *target, int32_t *b) {
  *target = 0xAAA + *b;
  return (int64_t) *target;   /* -O2: upper 32 bits taken from the un-extended add result */
}
```

returned 4294967023 instead of -273 at `-O2`/`-O3` (both x86_64 and aarch64, as the reporter observed — the bug is target-independent).

The fix, as sketched by @asumagic in the issue discussion: when forwarding from a **store**, materialize the forwarding temp with the extension insn matching the memory type (`ext32`/`uext32`/... ; full-width types keep the plain move). Load-load forwarding is unaffected — the previous load's result is already extended, and `mem_expr_eq` keys on `canonic_mem_type`, which keeps differently-signed narrow types distinct. The load's value number is now taken from the forwarding temp's def insn instead of the store's, since `ext(x)` and `x` are different values (keeping them equal would let later value-based folding repeat the same mistake).

Includes a self-checking regression test `c-tests/mir/issue423.mir` covering i32 (sign), u32 (zero) and i8 (sign) store-forwarding; it fails with exit code 1 on current master and passes at `-O0`..`-O3` with the fix. The original C reproducer prints -273 at `-O3` after the fix.

Validation: full `make test` green on x86_64 Linux (including all bootstrap rounds) and on aarch64 Linux (Graviton4, Ubuntu 24.04; the only failures are the three pre-existing `use-c2m-gen-bb` long-double failures noted in #430, present at the base commit); c-tests gen suite 1072/1072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
