### PR TITLE
Keep laddr/lref-referenced labels alive in jump_opt

### DIFF
--- a/c-tests/mir/issue424.mir
+++ b/c-tests/mir/issue424.mir
@@ -1,0 +1,22 @@
+M0:	module
+# jump_opt merged away a label-only BB whose label was referenced only by
+# lref data / laddr (not by any direct branch), freeing the label insn that
+# gen_setup_lrefs later reads and leaving the runtime label table pointing
+# at freed code (issue #424).
+	forward	la1
+main:	func	i32
+	local	i64:a, i64:r
+	mov	r, 0
+	mov	a, la1
+	mov	a, i64:0(a)
+	jmpi	a
+l1:
+l2:	add	r, r, 1
+	jmp	done
+done:	bne	fail, r, 1
+	ret	0
+fail:	ret	1
+	endfunc
+la1:	lref	l1
+	export	main
+	endmodule

--- a/mir-gen.c
+++ b/mir-gen.c
@@ -6652,6 +6652,12 @@ static void jump_opt (gen_ctx_t gen_ctx) {
     bb_insn_t bb_insn;
     int i, start_nop, bound_nop;
 
+    /* Labels whose address is taken (laddr) can be reached by jmpi and must
+       not be removed (issue #424): */
+    for (bb_insn = DLIST_HEAD (bb_insn_t, bb->bb_insns); bb_insn != NULL;
+         bb_insn = DLIST_NEXT (bb_insn_t, bb_insn))
+      if (bb_insn->insn->code == MIR_LADDR)
+        bitmap_set_bit_p (temp_bitmap, bb_insn->insn->ops[1].u.label->ops[0].u.u);
     if ((bb_insn = DLIST_TAIL (bb_insn_t, bb->bb_insns)) == NULL) continue;
     if (bb_insn->insn->code == MIR_SWITCH) {
       start_nop = 1;
@@ -6664,6 +6670,12 @@ static void jump_opt (gen_ctx_t gen_ctx) {
     }
     for (i = start_nop; i < bound_nop; i++)
       bitmap_set_bit_p (temp_bitmap, bb_insn->insn->ops[i].u.label->ops[0].u.u);
+  }
+  /* The same holds for labels whose address is stored in lref data, and
+     gen_setup_lrefs would read the freed label insns (issue #424): */
+  for (MIR_lref_data_t lref = curr_func_item->u.func->first_lref; lref != NULL; lref = lref->next) {
+    bitmap_set_bit_p (temp_bitmap, lref->label->ops[0].u.u);
+    if (lref->label2 != NULL) bitmap_set_bit_p (temp_bitmap, lref->label2->ops[0].u.u);
   }
   for (bb = DLIST_EL (bb_t, curr_cfg->bbs, 2); bb != NULL; bb = next_bb) {
     edge_t e, out_e;


### PR DESCRIPTION
Fixes #424.

`jump_opt`'s label-only-BB merging consults a bitmap of labels that must not be removed, built only from **branch/switch terminator** label operands. A label whose address is taken — referenced by an `laddr` insn operand or stored in `lref` data — can be the target of a `jmpi` without any direct branch to it. Its label-only BB was merged away and the label insn freed, after which:

- `gen_setup_lrefs` read the freed label insn (the heap-use-after-free in the issue's ASan trace), and
- the runtime label table was filled with garbage, sending the computed goto into freed or wrong code (in a non-ASan build the minimized reproducer below loops forever on a stale table entry).

The fix adds `laddr` operand labels and the function's `lref` labels (`func->first_lref`, including `label2`) to the do-not-remove bitmap — mirroring what `build_func_cfg` already does for reachability via `bb->reachable_p` and the `jmpi` successor edges.

Includes a self-checking regression test `c-tests/mir/issue424.mir`: a label-only BB whose label is referenced only through `lref` data, reached via `jmpi`. On current master it hangs (times out) at the default optimization level; with the fix it passes at `-O0`..`-O3`.

Validation: full `make test` green on x86_64 Linux (including all bootstrap rounds) and on aarch64 Linux (Graviton4, Ubuntu 24.04; only the pre-existing `use-c2m-gen-bb` long-double failures noted in #430 remain); c-tests gen suite 1072/1072.

Related: #426 (lref data also doesn't survive binary write/read) is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
