### PR TITLE
aarch64: fix long double stack alignment in va_arg_builtin and ff interface

### DIFF
--- a/c-tests/new/va-ld-stack.c
+++ b/c-tests/new/va-ld-stack.c
@@ -1,0 +1,27 @@
+/* Long double passed on the stack: with binary128 long double (e.g.
+   aarch64), FP args past the 8 v-registers go to the stack 16-aligned.
+   Exercises va_arg_builtin (varargs) and the ff interface (fixed args)
+   stack paths, which used "% 16" where round-up-to-16 was intended.  */
+#include <stdarg.h>
+
+long double vsum (int n, ...) {
+  va_list ap;
+  long double s = 0;
+
+  va_start (ap, n);
+  while (n--) s += va_arg (ap, long double);
+  va_end (ap);
+  return s;
+}
+
+long double fsum (long double a1, long double a2, long double a3, long double a4, long double a5,
+                  long double a6, long double a7, long double a8, long double a9,
+                  long double a10) {
+  return a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10;
+}
+
+int main (void) {
+  if (vsum (9, 1.L, 2.L, 3.L, 4.L, 5.L, 6.L, 7.L, 8.L, 9.L) != 45.L) return 1;
+  if (fsum (1.L, 2.L, 3.L, 4.L, 5.L, 6.L, 7.L, 8.L, 9.L, 10.L) != 55.L) return 2;
+  return 0;
+}

--- a/mir-aarch64.c
+++ b/mir-aarch64.c
@@ -91,7 +91,7 @@ void *va_arg_builtin (void *p, uint64_t t) {
     va->__gr_offs += 8;
   } else {
     if (type == MIR_T_LD && __SIZEOF_LONG_DOUBLE__ == 16)
-      va->__stack = (void *) (((uint64_t) va->__stack + 15) % 16);
+      va->__stack = (void *) (((uint64_t) va->__stack + 15) / 16 * 16);
     a = va->__stack;
     va->__stack
       = (char *) va->__stack + (type == MIR_T_LD && __SIZEOF_LONG_DOUBLE__ == 16 ? 16 : 8);
@@ -414,7 +414,8 @@ void *_MIR_get_ff_call (MIR_context_t ctx, size_t nres, MIR_type_t *res_types, s
       if (n_vregs < 8) {
         pat |= offset_imm | n_vregs++;
       } else {
-        if (type == MIR_T_LD && __SIZEOF_LONG_DOUBLE__ == 16) sp_offset = (sp_offset + 15) % 16;
+        if (type == MIR_T_LD && __SIZEOF_LONG_DOUBLE__ == 16)
+          sp_offset = (sp_offset + 15) / 16 * 16;
         pat |= offset_imm | temp_reg;
         push_insns (code, &pat, sizeof (pat));
         pat = type == MIR_T_F                                  ? sts_pat


### PR DESCRIPTION
Fixes #431.

Two places in `mir-aarch64.c` that intend to round a stack location up to 16 bytes (for binary128 `long double`) use `% 16` instead of `/ 16 * 16`:

- `va_arg_builtin`: `va->__stack` was replaced with a value in 0..15, so taking **any** `long double` vararg from the stack area (after the 8 v-registers are exhausted) dereferenced a near-NULL pointer — `c2m repro.c -eg` and `-ei` both segfault on Linux aarch64 (see the issue for the 10-line reproducer).
- `_MIR_get_ff_call`: the running `sp_offset` was reset to 0..15, storing `long double` args past the 8 v-registers at the wrong stack slot.

The correct idiom already appears at the end of the same function (`sp_offset = (sp_offset + 15) / 16 * 16;`).

Includes a regression test `c-tests/new/va-ld-stack.c` (9 `long double` varargs + 10 fixed `long double` args, forcing both stack paths). It is valid C for all targets; on Linux aarch64 it segfaults in both `-eg` and `-ei` on current master and passes with the fix.

Validation: full `make test` green on aarch64 Linux (Graviton4, Ubuntu 24.04; only the pre-existing `use-c2m-gen-bb` long-double failures noted in #430 remain) and on x86_64 Linux (unaffected by the change, test passes there as a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
