### PR TITLE
Support musl libc (Alpine) in the test harness

### DIFF
--- a/c-tests/runtests.sh
+++ b/c-tests/runtests.sh
@@ -34,6 +34,13 @@ else
     ARCH="other"
 fi
 
+# busybox diff (e.g. on Alpine) lacks --strip-trailing-cr
+if diff --strip-trailing-cr /dev/null /dev/null >/dev/null 2>&1;then
+    DIFF_STRIP_CR=--strip-trailing-cr
+else
+    DIFF_STRIP_CR=
+fi
+
 runtest () {
 	t=$1
 	if test -f $t.mach && ! $GREP -E "`uname -m`" $t.mach >/dev/null; then
@@ -57,14 +64,14 @@ runtest () {
 	$TIMEOUT sh $execution_program $compiler $t $add_main 2>$stderrf >$outf
 	code=$?
 	if test $code = $expect_code; then
-	    if test x$expect_out != x && ! diff --strip-trailing-cr -up $expect_out $outf >$errf;then
+	    if test x$expect_out != x && ! diff $DIFF_STRIP_CR -up $expect_out $outf >$errf;then
 	            $ECHO Output mismatch
 		    cat $errf
             else
 		    ok=`expr $ok + 1`
 	            $ECHO -ne "OK               \r"
 	    fi
-	    if test x$stderr_expect_out != x && ! diff --strip-trailing-cr -up $stderr_expect_out $stderrf >$errf;then
+	    if test x$stderr_expect_out != x && ! diff $DIFF_STRIP_CR -up $stderr_expect_out $stderrf >$errf;then
 	            $ECHO Stderr mismatch
 		    cat $errf
             else

--- a/c2mir/aarch64/mirc_aarch64_linux.h
+++ b/c2mir/aarch64/mirc_aarch64_linux.h
@@ -52,11 +52,13 @@ static char aarch64_mirc[]
     "#define __UINT32_MAX__ (__INT32_MAX__ * 2u + 1u)\n"
     "#define __UINT64_MAX__ (__INT64_MAX__ * 2u + 1u)\n"
 #if defined(__linux__)
-    "#define __WCHAR_MAX__ 0x7fffffff\n"
+    /* wchar_t is unsigned int in AAPCS64 */
+    "#define __WCHAR_MAX__ 4294967295u\n"
+    "#define __WCHAR_MIN__ 0u\n"
 #else
     "#define __WCHAR_MAX__ 2147483647\n"
-#endif
     "#define __WCHAR_MIN__ (-__WCHAR_MAX__ - 1)\n"
+#endif
     "#define __SCHAR_MAX__ __INT8_MAX__\n"
     "#define __SHRT_MAX__ __INT16_MAX__\n"
     "#define __INT_MAX__ __INT32_MAX__\n"

--- a/c2mir/aarch64/mirc_aarch64_stddef.h
+++ b/c2mir/aarch64/mirc_aarch64_stddef.h
@@ -10,7 +10,12 @@ static char stddef_str[]
     "typedef long ptrdiff_t;\n"
     "typedef unsigned long size_t;\n"
     "typedef long double max_align_t;\n"
+#if defined(__APPLE__)
     "typedef int wchar_t;\n"
+#else
+    /* unsigned in AAPCS64; matters because musl's alltypes.h redeclares it */
+    "typedef unsigned int wchar_t;\n"
+#endif
     "\n"
     "#define NULL ((void *) 0)\n"
     "\n"

--- a/c2mir/c2mir-driver.c
+++ b/c2mir/c2mir-driver.c
@@ -65,7 +65,29 @@ struct lib {
 typedef struct lib lib_t;
 
 #if defined(__unix__)
-#if UINTPTR_MAX == 0xffffffff
+#if defined(__linux__) && !defined(__GLIBC__)
+/* A non-glibc Linux libc, e.g. musl on Alpine: libc, libm, libpthread, and
+   libdl all live in one shared object, installed as the dynamic loader
+   /lib/ld-musl-<arch>.so.1 on musl.  */
+#if defined(__x86_64__)
+#define MUSL_LIB_ARCH "x86_64"
+#elif defined(__aarch64__)
+#define MUSL_LIB_ARCH "aarch64"
+#elif defined(__PPC64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MUSL_LIB_ARCH "powerpc64le"
+#elif defined(__PPC64__)
+#define MUSL_LIB_ARCH "powerpc64"
+#elif defined(__s390x__)
+#define MUSL_LIB_ARCH "s390x"
+#elif defined(__riscv)
+#define MUSL_LIB_ARCH "riscv64"
+#else
+#error cannot recognize the non-glibc linux target
+#endif
+static lib_t std_libs[]
+  = {{"/lib/ld-musl-" MUSL_LIB_ARCH ".so.1", NULL}, {"/usr/lib/libc.so", NULL}};
+static const char *std_lib_dirs[] = {"/lib", "/usr/lib"};
+#elif UINTPTR_MAX == 0xffffffff
 static lib_t std_libs[]
   = {{"/lib/libc.so", NULL},         {"/lib/libm.so", NULL},          {"/lib/libc.so.6", NULL},
      {"/lib32/libc.so.6", NULL},     {"/lib/libm.so.6", NULL},        {"/lib32/libm.so.6", NULL},

--- a/mir-bin-driver.c
+++ b/mir-bin-driver.c
@@ -24,7 +24,25 @@ static struct lib {
   char *name;
   void *handler;
 } libs[] = {
-#if !defined(__APPLE__)
+#if defined(__linux__) && !defined(__GLIBC__)
+/* A non-glibc Linux libc, e.g. musl on Alpine: everything lives in one
+   shared object, installed as the dynamic loader on musl.  */
+#if defined(__x86_64__)
+  {"/lib/ld-musl-x86_64.so.1", NULL}
+#elif defined(__aarch64__)
+  {"/lib/ld-musl-aarch64.so.1", NULL}
+#elif defined(__PPC64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  {"/lib/ld-musl-powerpc64le.so.1", NULL}
+#elif defined(__PPC64__)
+  {"/lib/ld-musl-powerpc64.so.1", NULL}
+#elif defined(__s390x__)
+  {"/lib/ld-musl-s390x.so.1", NULL}
+#elif defined(__riscv)
+  {"/lib/ld-musl-riscv64.so.1", NULL}
+#else
+#error cannot recognize the non-glibc linux target
+#endif
+#elif !defined(__APPLE__)
   {"/lib64/libc.so.6", NULL}, {"/lib64/libm.so.6", NULL}, {"/lib64/libpthread.so.0", NULL}
 #else
   {"/usr/lib/libc.dylib", NULL}, {"/usr/lib/libm.dylib", NULL}

--- a/mir-bin-run.c
+++ b/mir-bin-run.c
@@ -28,7 +28,29 @@ typedef struct lib lib_t;
 
 /* stdlibs according to c2mir */
 #if defined(__unix__)
-#if UINTPTR_MAX == 0xffffffff
+#if defined(__linux__) && !defined(__GLIBC__)
+/* A non-glibc Linux libc, e.g. musl on Alpine: libc, libm, libpthread, and
+   libdl all live in one shared object, installed as the dynamic loader
+   /lib/ld-musl-<arch>.so.1 on musl.  */
+#if defined(__x86_64__)
+#define MUSL_LIB_ARCH "x86_64"
+#elif defined(__aarch64__)
+#define MUSL_LIB_ARCH "aarch64"
+#elif defined(__PPC64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define MUSL_LIB_ARCH "powerpc64le"
+#elif defined(__PPC64__)
+#define MUSL_LIB_ARCH "powerpc64"
+#elif defined(__s390x__)
+#define MUSL_LIB_ARCH "s390x"
+#elif defined(__riscv)
+#define MUSL_LIB_ARCH "riscv64"
+#else
+#error cannot recognize the non-glibc linux target
+#endif
+static lib_t std_libs[]
+  = {{"/lib/ld-musl-" MUSL_LIB_ARCH ".so.1", NULL}, {"/usr/lib/libc.so", NULL}};
+static const char *std_lib_dirs[] = {"/lib", "/usr/lib"};
+#elif UINTPTR_MAX == 0xffffffff
 static lib_t std_libs[]
   = {{"/lib/libc.so.6", NULL},   {"/lib32/libc.so.6", NULL},     {"/lib/libm.so.6", NULL},
      {"/lib32/libm.so.6", NULL}, {"/lib/libpthread.so.0", NULL}, {"/lib32/libpthread.so.0", NULL}};


### PR DESCRIPTION
Fixes #307.

The test harness assumed glibc in three ways, making `make test` unusable on musl distributions like Alpine:

- **Driver dlopen tables**: c2mir-driver.c, mir-bin-run.c, and mir-bin-driver.c resolve external symbols for executed programs by dlopening hardcoded glibc paths (`/lib64/libc.so.6`, `/lib/<triplet>-linux-gnu/libc.so.6`, ...), so every executed test failed with e.g. `can not load symbol printf` — the #307 symptom — and mir-bin-driver exited before running anything. On musl, libc, libm, libpthread, and libdl are all one shared object installed as the dynamic loader `/lib/ld-musl-<arch>.so.1`: a `__linux__ && !__GLIBC__` branch adds that path to all three tables.

- **BusyBox diff**: runtests.sh passes `--strip-trailing-cr` unconditionally; BusyBox diff (Alpine's default) rejects it, so every `.expect` comparison errored and was counted as an output mismatch (30 phantom failures per execution mode). The option is now probed once at startup.

- **c2mir's aarch64 builtin stddef.h** declared `typedef int wchar_t;`, but wchar_t is *unsigned* int in AAPCS64 (caarch64.h already says `MIR_WCHAR_MIN 0`). glibc never notices because its headers trust the compiler's stddef.h, but musl's `bits/alltypes.h` redeclares wchar_t per-arch (`typedef unsigned wchar_t;`), making every program that includes both fail with `repeated declaration wchar_t` — this broke the c2m bootstrap on Alpine aarch64. Fixed to unsigned (kept `int` on Apple, where wchar_t really is signed), and the `__WCHAR_MAX__`/`__WCHAR_MIN__` predefines on Linux corrected to gcc's values (`4294967295u` / `0u`).

## Validation

Alpine 3.23.4 aarch64 (EC2 Graviton, gcc 15.2, BusyBox userland): `make test` now runs to completion. c-tests interp mode is fully green (1073/1073); the gen modes fail only `c-tests/new/jcall.c` (a pre-existing crash after `main` returns involving `__builtin_jcall`/`__builtin_jret` with a global register variable — it also reproduces with this patch reverted, fails identically in all gen modes, and passes under the interpreter; happy to file separately). All bootstrap rounds pass, including the bb-versioning bootstrap given enough RAM (it is the suite's peak memory consumer; it gets OOM-killed on a 1GB box).

x86_64 glibc: full `make test` remains green (the new code paths are compiled out there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
