### PR TITLE
Fix lazy BB generation when code mappings are out of direct-branch range (aarch64 x9 clobber + code-space reservation)

### DIFF
--- a/mir-aarch64.c
+++ b/mir-aarch64.c
@@ -207,8 +207,10 @@ void *_MIR_get_thunk (MIR_context_t ctx) {
   return _MIR_publish_code (ctx, (uint8_t *) pat, sizeof (pat));
 }
 
-void _MIR_redirect_thunk (MIR_context_t ctx, void *thunk, void *to) {
-  static const uint32_t branch_pat1 = 0xd61f0120; /* br x9 */
+/* The far form clobbers x<temp_reg>: callers must pick a register that holds
+   nothing live at the redirect site.  */
+static void redirect_thunk_by_reg (MIR_context_t ctx, void *thunk, void *to,
+                                   unsigned temp_reg) {
   static const uint32_t branch_pat2 = 0x14000000; /* b x */
   int64_t offset = (uint32_t *) to - (uint32_t *) thunk;
   uint32_t code[4];
@@ -218,11 +220,15 @@ void _MIR_redirect_thunk (MIR_context_t ctx, void *thunk, void *to) {
     code[0] = branch_pat2 | ((uint32_t) offset & BR_OFFSET_MASK);
     _MIR_change_code (ctx, thunk, (uint8_t *) &code[0], sizeof (code[0]));
   } else {
-    code[0] = 0x58000049; /* ldr x9,8 (pc-relative) */
-    code[1] = branch_pat1;
+    code[0] = 0x58000040 | temp_reg;        /* ldr x<temp_reg>,8 (pc-relative) */
+    code[1] = 0xd61f0000 | (temp_reg << 5); /* br x<temp_reg> */
     *(void **) &code[2] = to;
     _MIR_change_code (ctx, thunk, (uint8_t *) code, sizeof (code));
   }
+}
+
+void _MIR_redirect_thunk (MIR_context_t ctx, void *thunk, void *to) {
+  redirect_thunk_by_reg (ctx, thunk, to, 9);
 }
 
 void *_MIR_get_thunk_addr (MIR_context_t ctx MIR_UNUSED, void *thunk) {
@@ -756,7 +762,12 @@ void *_MIR_get_bb_thunk (MIR_context_t ctx, void *bb_version, void *handler) {
   offset = gen_mov_addr (code, 9, bb_version); /* x9 = bb_version */
   push_insns (code, pat, sizeof (pat));
   res = _MIR_publish_code (ctx, VARR_ADDR (uint8_t, code), VARR_LENGTH (uint8_t, code));
-  _MIR_redirect_thunk (ctx, (uint8_t *) res + offset, handler);
+  /* x9 carries bb_version to the handler, so the branch to the handler must
+     not use _MIR_redirect_thunk's x9-based far form: when the thunk ends up
+     farther than a direct branch can reach (+-128MB) from the handler, the
+     handler would receive its own address instead of bb_version.  Use x10,
+     the other fixed temp not used in machinized code.  */
+  redirect_thunk_by_reg (ctx, (uint8_t *) res + offset, handler, 10);
 #if 0
   if (getenv ("MIR_code_dump") != NULL)
     _MIR_dump_code ("bb thunk:", res, VARR_LENGTH (uint8_t, code));

--- a/mir.c
+++ b/mir.c
@@ -4361,10 +4361,33 @@ DEF_VARR (code_holder_t);
 struct machine_code_ctx {
   VARR (code_holder_t) * code_holders;
   size_t page_size;
+  uint8_t *code_reserve_start, *code_reserve_free, *code_reserve_bound;
 };
 
 #define code_holders ctx->machine_code_ctx->code_holders
 #define page_size ctx->machine_code_ctx->page_size
+#define code_reserve_start ctx->machine_code_ctx->code_reserve_start
+#define code_reserve_free ctx->machine_code_ctx->code_reserve_free
+#define code_reserve_bound ctx->machine_code_ctx->code_reserve_bound
+
+/* Generated code, thunks, and wrappers reference each other with direct
+   branches whose reach is limited on some targets (e.g. +-128MB on aarch64).
+   Carving all code holders out of one contiguous address-space reservation
+   keeps every piece of generated code within direct branch range of every
+   other one.  The reservation is address space only: untouched pages cost no
+   memory.  Without it, code mappings can end up scattered across the address
+   space -- the libc allocator's own mmaps land between them -- which breaks
+   the bb thunk -> bb wrapper and generated-code -> bb thunk branches of
+   lazy basic-block generation (seen with musl libc's allocator on aarch64).
+   If the reservation is exhausted or unavailable, fall back to individual
+   mappings as before.  */
+#ifndef MIR_CODE_RESERVE_SIZE
+#if UINTPTR_MAX == 0xffffffffffffffffu && !defined(_WIN32)
+#define MIR_CODE_RESERVE_SIZE (128 * 1024 * 1024)
+#else
+#define MIR_CODE_RESERVE_SIZE 0 /* scarce address space (or Windows commit charge) */
+#endif
+#endif
 
 static code_holder_t *get_last_code_holder (MIR_context_t ctx, size_t size) {
   uint8_t *mem;
@@ -4378,8 +4401,13 @@ static code_holder_t *get_last_code_holder (MIR_context_t ctx, size_t size) {
   }
   npages = (size + page_size) / page_size;
   len = page_size * npages;
-  mem = (uint8_t *) MIR_mem_map (ctx->code_alloc, len);
-  if (mem == MAP_FAILED) return NULL;
+  if (code_reserve_start != NULL && (size_t) (code_reserve_bound - code_reserve_free) >= len) {
+    mem = code_reserve_free;
+    code_reserve_free += len;
+  } else {
+    mem = (uint8_t *) MIR_mem_map (ctx->code_alloc, len);
+    if (mem == MAP_FAILED) return NULL;
+  }
   ch.start = mem;
   ch.free = mem;
   ch.bound = mem + len;
@@ -4494,13 +4522,26 @@ static void code_init (MIR_context_t ctx) {
     MIR_get_error_func (ctx) (MIR_alloc_error, "Not enough memory for ctx");
   page_size = mem_page_size ();
   VARR_CREATE (code_holder_t, code_holders, ctx->alloc, 128);
+  code_reserve_start = code_reserve_free = code_reserve_bound = NULL;
+  if (MIR_CODE_RESERVE_SIZE != 0) {
+    uint8_t *mem = (uint8_t *) MIR_mem_map (ctx->code_alloc, MIR_CODE_RESERVE_SIZE);
+    if (mem != MAP_FAILED) {
+      code_reserve_start = code_reserve_free = mem;
+      code_reserve_bound = mem + MIR_CODE_RESERVE_SIZE;
+    }
+  }
 }
 
 static void code_finish (MIR_context_t ctx) {
   while (VARR_LENGTH (code_holder_t, code_holders) != 0) {
     code_holder_t ch = VARR_POP (code_holder_t, code_holders);
+    if (code_reserve_start != NULL && ch.start >= code_reserve_start
+        && ch.start < code_reserve_bound)
+      continue; /* carved from the reservation, unmapped below as a whole */
     MIR_mem_unmap (ctx->code_alloc, ch.start, ch.bound - ch.start);
   }
+  if (code_reserve_start != NULL)
+    MIR_mem_unmap (ctx->code_alloc, code_reserve_start, code_reserve_bound - code_reserve_start);
   VARR_DESTROY (code_holder_t, code_holders);
   MIR_free (ctx->alloc, ctx->machine_code_ctx);
   ctx->machine_code_ctx = NULL;


### PR DESCRIPTION
Fixes #436 (deterministic ~8GB OOM of `c2mir-bb-bootstrap-test` on aarch64 musl; latent on glibc for large enough `-eb` workloads). Full analysis in the issue; summary:

**Commit 1 — aarch64: do not clobber x9 in the bb thunk's branch to the bb wrapper.**
The bb thunk is `mov x9, <bb_version>; branch to wrapper`, but `_MIR_redirect_thunk`'s far form is `ldr x9, 8; br x9`, so a thunk published out of direct-branch range (±128MB) of the wrapper delivers the wrapper's own address as `bb_version`. The generator then reads wrapper machine code as a `struct bb_version`, and the garbage `attrs[].spot` values grow `spot2attr` toward tens of GB. Parameterize the redirect by temp register and use x10 (the other fixed temp not used in machinized code) for the thunk→handler branch — the same approach riscv64 already uses (`redirect_thunk(..., T6_HARD_REG)` with the payload in t5). x16/x17 are not used because MIR's RA can allocate them, and a bb border may have them live.

**Commit 2 — carve code holders out of one contiguous address-space reservation.**
With commit 1 alone the bootstrap next hits `too big offset (...) in setup_rel`: generated bb code also branches directly to successor bb thunks, and `target_redirect_bb_origin_branch` patches direct branches to generated successors — all assuming everything is within direct-branch reach. Reserve one contiguous 128MB range up front (64-bit non-Windows hosts; address space only, untouched pages cost no memory) and carve code holders from it, falling back to individual mappings when the reservation is unavailable or exhausted. This makes the all-JIT-code-within-branch-range invariant hold by construction; musl's mmap-heavy allocator can no longer scatter the code mappings (and x86_64's `jmp rel32` bb thunks get the same protection against the ±2GB analogue).

Validation:
- aarch64 musl (Alpine 3.23, EC2 c8g.large): `c2mir-bb-bootstrap-test` passes in ~7s at 535MB peak RSS (previously >7.8GB and OOM-killed); full `make test` green.
- aarch64 glibc (Ubuntu 24.04): full `make test` green.
- x86_64 glibc: full `make test` green, bb bootstrap 575MB peak (unchanged).
