### PR TITLE
Fix x86-64 va_start offsets for functions with block args

### DIFF
--- a/c-tests/new/va-struct-args.c
+++ b/c-tests/new/va-struct-args.c
@@ -1,0 +1,55 @@
+/* Named struct parameters before the ellipsis must not break va_arg.
+   On x86-64 va_start used to recompute the named args' layout instead of
+   using the machinize walk's state: register-passed blocks were neither
+   counted into gp_offset/fp_offset nor excluded from the overflow area,
+   and memory-passed blocks were counted without 8-byte rounding. */
+#include <stdarg.h>
+
+struct IS {
+  long a;
+};                          /* 1 GPR */
+struct FS {
+  double d;
+};                          /* 1 XMM */
+struct MS {
+  char c[17];
+};                          /* memory, size not a multiple of 8 */
+
+static int reg_int_structs (struct IS s1, struct IS s2, int z, ...) {
+  va_list ap;
+  va_start (ap, z);
+  int v = va_arg (ap, int);
+  va_end (ap);
+  return v;
+}
+
+static double reg_fp_structs (struct FS f1, struct FS f2, double z, ...) {
+  va_list ap;
+  va_start (ap, z);
+  double v = va_arg (ap, double);
+  va_end (ap);
+  return v;
+}
+
+static int mem_structs (struct MS m1, struct MS m2, struct MS m3, struct MS m4, struct MS m5,
+                        struct MS m6, struct MS m7, int g1, int g2, int g3, int g4, int g5,
+                        int g6, ...) {
+  /* All GPRs consumed by g1..g6: the vararg comes from the overflow area,
+     right after the seven 24-byte-rounded structs. */
+  va_list ap;
+  va_start (ap, g6);
+  int v = va_arg (ap, int);
+  va_end (ap);
+  return v;
+}
+
+int main (void) {
+  struct IS s1 = {111}, s2 = {222};
+  struct FS f1 = {1.5}, f2 = {2.5};
+  struct MS m = {{0}};
+
+  if (reg_int_structs (s1, s2, 3, 42) != 42) return 1;
+  if (reg_fp_structs (f1, f2, 3.0, 43.0) != 43.0) return 2;
+  if (mem_structs (m, m, m, m, m, m, m, 1, 2, 3, 4, 5, 6, 44) != 44) return 3;
+  return 0;
+}

--- a/mir-gen-x86_64.c
+++ b/mir-gen-x86_64.c
@@ -859,24 +859,14 @@ static void target_machinize (gen_ctx_t gen_ctx) {
       MIR_op_t va_op = insn->ops[0];
       MIR_reg_t va_reg;
 #ifndef _WIN32
-      int gp_offset = 0, fp_offset = 48, mem_offset = 0;
-      MIR_var_t var;
+      /* Use the arg passing state left by the prologue walk above: it is the
+         only way to agree with the actual layout (register classes of block
+         args, 8-byte rounding of memory-passed blocks, reg exhaustion). */
+      int gp_offset = (int) (int_arg_num > 6 ? 48 : int_arg_num * 8);
+      int fp_offset = (int) (48 + (fp_arg_num > 8 ? 128 : fp_arg_num * 16));
+      int64_t mem_offset = (int64_t) (mem_size - spill_space_size);
 
       assert (func->vararg_p && va_op.mode == MIR_OP_VAR);
-      for (uint32_t narg = 0; narg < func->nargs; narg++) {
-        var = VARR_GET (MIR_var_t, func->vars, narg);
-        if (var.type == MIR_T_F || var.type == MIR_T_D) {
-          fp_offset += 16;
-          if (gp_offset >= 176) mem_offset += 8;
-        } else if (var.type == MIR_T_LD) {
-          mem_offset += 16;
-        } else if (MIR_blk_type_p (var.type)) {
-          mem_offset += var.size;
-        } else { /* including RBLK */
-          gp_offset += 8;
-          if (gp_offset >= 48) mem_offset += 8;
-        }
-      }
       va_reg = va_op.u.var;
       /* Insns can be not simplified as soon as they match a machine insn.  */
       /* mem32[va_reg] = gp_offset; mem32[va_reg] = fp_offset */


### PR DESCRIPTION
On x86-64, `va_start` machinization re-derives the named arguments' register/stack layout with its own scan over `func->vars` instead of using the state the prologue arg walk just computed, and that scan disagrees with the actual layout in three ways:

* **register-passed blocks** (`MIR_T_BLK+1`/`+2`/...) are not counted into `gp_offset`/`fp_offset`, so the first `va_arg` reads the named structs' registers out of the save area as if they were the varargs;
* **every block** is added to the overflow-area displacement — including ones actually passed in registers — and without the 8-byte rounding the argument area applies (`(size + 7) / 8 * 8` in the same function), so stack-passed varargs are read from wrong offsets;
* the FP exhaustion test checks `gp_offset >= 176` where `fp_offset` was presumably meant.

Minimal reproducer (current master, `c2m -eg`, Linux x86-64):

```c
#include <stdarg.h>
struct S { long a; };
int f (struct S s1, struct S s2, int z, ...) {
  va_list ap;
  va_start (ap, z);
  int v = va_arg (ap, int);   /* returns s2.a instead of 42 */
  va_end (ap);
  return v;
}
int main (void) { struct S s1 = {111}, s2 = {222}; return f (s1, s2, 3, 42) != 42; }
```

The fix replaces the scan with the `int_arg_num`/`fp_arg_num`/`mem_size` totals left by the prologue arg walk a few lines above — the same thing the aarch64 port already does — so the offsets agree with the layout by construction.

Includes a self-checking regression test `c-tests/new/va-struct-args.c` covering the register-class cases (GPR-passed and XMM-passed single-field structs before the ellipsis) and the memory case (17-byte structs whose unrounded sizes used to misplace the overflow area). It fails on current master and passes with the fix under `-ei`, `-eg`, `-eb`, `-O0` and `-O3`. Full `make test` is green on x86_64 Linux.
