### PR TITLE
Allow vararg functions without any named parameter (C23)

### DIFF
--- a/c-tests/mir/paramless-vararg.mir
+++ b/c-tests/mir/paramless-vararg.mir
@@ -1,0 +1,33 @@
+M0:	module
+# C23 allows variadic functions without any named parameter (int f(...)).
+# Nothing in the implementation needs a named argument: the register save
+# area and va_start lowering depend only on vararg_p.
+vasum:	func	i64, ...
+	local	i64:cnt, i64:sum, i64:i, i64:v, i64:va
+	alloca	va, 48
+	va_start	va
+	va_arg	v, va, i64:0
+	mov	cnt, i64:0(v)
+	mov	sum, 0
+	mov	i, 0
+loop:
+	bge	fin, i, cnt
+	va_arg	v, va, i64:0
+	add	sum, sum, i64:0(v)
+	add	i, i, 1
+	jmp	loop
+fin:
+	va_end	va
+	ret	sum
+	endfunc
+p:	proto	i64, ...
+main:	func	i32
+	local	i64:r, i64:fa
+	mov	fa, vasum
+	call	p, fa, r, 3, 10, 20, 12
+	bne	fail, r, 42
+	ret	0
+fail:	ret	1
+	endfunc
+	export	main
+	endmodule

--- a/mir.c
+++ b/mir.c
@@ -1387,9 +1387,6 @@ static MIR_item_t new_func_arr (MIR_context_t ctx, const char *name, size_t nres
     MIR_get_error_func (ctx) (MIR_nested_func_error,
                               "Creating function when previous function %s is not finished",
                               curr_func->name);
-  if (nargs == 0 && vararg_p)
-    MIR_get_error_func (ctx) (MIR_vararg_func_error,
-                              "Variable arg function %s w/o any mandatory argument", name);
   for (size_t i = 0; i < nres; i++)
     if (wrong_type_p (res_types[i]))
       MIR_get_error_func (ctx) (MIR_wrong_type_error, "wrong result type in func %s", name);


### PR DESCRIPTION
C23 makes variadic functions without any named parameter valid C (`int f(...)` with the new one-argument `va_start(ap)`), but `MIR_new_{vararg_,}func_arr` rejected `nargs == 0 && vararg_p` with "Variable arg function w/o any mandatory argument".

Investigating it for a C23 frontend targeting MIR, the restriction turned out to be front-end-only — nothing in the implementation needs a named argument:

* the register save areas are set up whenever `vararg_p` is set, independent of `nargs`;
* both the x86-64 and aarch64 `va_start` lowerings derive their offsets by walking the named args from zero, which degenerates correctly to "everything is a vararg";
* protos with zero named args were already accepted, so *calling* such functions worked all along — only defining them was blocked;
* the textual writer even anticipates the case (`nargs == 0 && nres == 0 ? "..." : ", ..."`).

This PR just removes the check. With it gone, such functions scan from textual MIR, survive a binary `MIR_write`/`MIR_read` round trip, and execute correctly through both the interpreter (incl. the native→interp shim) and the generator.

c2mir is unaffected: its C11 grammar already rejects `(...)` with its own syntax error before anything reaches the MIR layer, so no diagnostic is lost for C11 code.

Includes a self-checking regression test `c-tests/mir/paramless-vararg.mir` (a paramless variadic summing its integer varargs via `va_start`/`va_arg`); it runs under `-ei`, `-eg`, and `-eb`. Full `make test` is green on x86_64 Linux with the change.

Found while developing a C23 frontend (slimcc) that emits MIR; with this change (and PR #438) the frontend's full C23 paramless-variadic tests pass under JIT execution.
