### PR TITLE
Fix clobbering of arg regs by block arg copies (aarch64, riscv64, s390x, ppc64)

### DIFF
--- a/c-tests/mir/big-blk-arg.mir
+++ b/c-tests/mir/big-blk-arg.mir
@@ -1,0 +1,31 @@
+# Args already in caller-saved regs (FP args in v0-v7, int args past the
+# old save_regs band-aid in x3-x7 on aarch64) used to be clobbered by the
+# mir.blk_mov call copying a by-reference (> 16 qwords) block arg, because
+# the copy was emitted after the argument hard reg loads.  c2mir never
+# emits such calls (it lowers big aggregates itself), so this needs a raw
+# MIR test.  Expected result: 1.5+2.25+10+20+30+40+100+4.25 = 208.0.
+m_bba:  module
+pf:     proto d, d:d1, d:d2, i64:i1, i64:i2, i64:i3, i64:i4, blk:200(b), d:d3
+fsum:   func d, d:d1, d:d2, i64:i1, i64:i2, i64:i3, i64:i4, blk:200(b), d:d3
+        local i64:t, i64:tc, d:s, d:td
+        dadd s, d1, d2
+        dadd s, s, d3
+        add t, i1, i2
+        add t, t, i3
+        add t, t, i4
+        mov tc, i8:100(b)
+        add t, t, tc
+        i2d td, t
+        dadd s, s, td
+        ret s
+        endfunc
+main:   func i64
+        local i64:a, d:r
+        alloca a, 200
+        mov i8:100(a), 100
+        call pf, fsum, r, 1.5, 2.25, 10, 20, 30, 40, blk:200(a), 4.25
+        dbne fail, r, 208.0
+        ret 0
+fail:   ret 1
+        endfunc
+        endmodule

--- a/c-tests/mir/big-blk-arg2.mir
+++ b/c-tests/mir/big-blk-arg2.mir
@@ -1,23 +1,27 @@
-# Variadic mirror of the same bug, modeled on slimcc's emission for its
-# function2.c struct_test130/131: every value is pre-loaded into a typed
-# temp before the call (so several FP/LD temps are live across the block
-# copies) and the per-call proto names all actual args before the "...".
+# Mirror of a JIT frontend's emission for struct-heavy variadic calls:
+# every value is pre-loaded into a typed temp before the call, so several
+# FP temps are live across the by-reference block copies.  Unfixed, the
+# mir.blk_mov calls doing those copies were emitted after earlier args
+# were already in caller-saved hard regs: base aarch64 read the first
+# double vararg wrongly (rc 1), base riscv64 crashed (the gen_blk_mov
+# band-aid restored saved a2 into the stack pointer), base s390x read
+# wrong values (rc 1).
 # (Distinct va_block_arg dest buffers on purpose: reusing one register
-# for both crashes gen copy_prop - separate bug.)
-# Unfixed aarch64 read ld1 as the *last* LD's value, the int as a stale
-# blk_mov size, and the doubles as 0.
+# for both crashes gen copy_prop - see issue #441.  Varargs deliberately
+# unnamed in the proto: riscv64 passes variadic FP args in GPRs, so a
+# proto naming them would change their ABI class.)
 m_bba2:	module
-pv:	proto	i64, i64:a0, i64:a1, ld:a2, blk:999(a3), i64:a4, d:a5, d:a6, d:a7, d:a8, blk:999(a9), ld:a10, ...
+pv:	proto	i64, i64:a0, i64:a1, ...
 vf:	func	i64, i64:i0, i64:i1, ...
-	local	i64:va, i64:p, i64:bs, i64:bs2, i64:t, i64:x, d:dv, d:dx, ld:lv, ld:lx
+	local	i64:va, i64:p, i64:bs, i64:bs2, i64:t, i64:x, d:dv, d:dx
 	alloca	va, 48
 	alloca	bs, 1000
 	alloca	bs2, 1000
 	va_start	va
-	va_arg	p, va, ld:0
-	ldmov	lv, ld:0(p)
-	ldmov	lx, 2.5L
-	ldbne	fail1, lv, lx
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 2.5
+	dbne	fail1, dv, dx
 	va_block_arg	bs, va, 999, 0
 	mov	t, i8:123(bs)
 	mov	x, 77
@@ -46,10 +50,10 @@ vf:	func	i64, i64:i0, i64:i1, ...
 	mov	t, i8:456(bs2)
 	mov	x, 78
 	bne	fail5, t, x
-	va_arg	p, va, ld:0
-	ldmov	lv, ld:0(p)
-	ldmov	lx, 11.5L
-	ldbne	fail6, lv, lx
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 11.5
+	dbne	fail6, dv, dx
 	va_end	va
 	ret	0
 fail1:	ret	1
@@ -60,7 +64,7 @@ fail5:	ret	5
 fail6:	ret	6
 	endfunc
 main:	func	i64
-	local	i64:a, i64:r, i64:t, i64:v1, i64:v2, i64:v3, ld:c1, ld:c2
+	local	i64:a, i64:r, i64:t, i64:v1, i64:v2, i64:v3, d:c1, d:c2
 	local	d:d1, d:d2, d:d3, d:d4
 	alloca	a, 1000
 	mov	t, 77
@@ -69,13 +73,13 @@ main:	func	i64
 	mov	i8:456(a), t
 	mov	v1, 11
 	mov	v2, 22
-	ldmov	c1, 2.5L
+	dmov	c1, 2.5
 	mov	v3, 33
 	dmov	d1, 4.5
 	dmov	d2, 5.5
 	dmov	d3, 6.5
 	dmov	d4, 7.5
-	ldmov	c2, 11.5L
+	dmov	c2, 11.5
 	call	pv, vf, r, v1, v2, c1, blk:999(a), v3, d1, d2, d3, d4, blk:999(a), c2
 	bne	fail, r, 0
 	ret	0

--- a/c-tests/mir/big-blk-arg2.mir
+++ b/c-tests/mir/big-blk-arg2.mir
@@ -1,0 +1,85 @@
+# Variadic mirror of the same bug, modeled on slimcc's emission for its
+# function2.c struct_test130/131: every value is pre-loaded into a typed
+# temp before the call (so several FP/LD temps are live across the block
+# copies) and the per-call proto names all actual args before the "...".
+# (Distinct va_block_arg dest buffers on purpose: reusing one register
+# for both crashes gen copy_prop - separate bug.)
+# Unfixed aarch64 read ld1 as the *last* LD's value, the int as a stale
+# blk_mov size, and the doubles as 0.
+m_bba2:	module
+pv:	proto	i64, i64:a0, i64:a1, ld:a2, blk:999(a3), i64:a4, d:a5, d:a6, d:a7, d:a8, blk:999(a9), ld:a10, ...
+vf:	func	i64, i64:i0, i64:i1, ...
+	local	i64:va, i64:p, i64:bs, i64:bs2, i64:t, i64:x, d:dv, d:dx, ld:lv, ld:lx
+	alloca	va, 48
+	alloca	bs, 1000
+	alloca	bs2, 1000
+	va_start	va
+	va_arg	p, va, ld:0
+	ldmov	lv, ld:0(p)
+	ldmov	lx, 2.5L
+	ldbne	fail1, lv, lx
+	va_block_arg	bs, va, 999, 0
+	mov	t, i8:123(bs)
+	mov	x, 77
+	bne	fail2, t, x
+	va_arg	p, va, i64:0
+	mov	t, i64:0(p)
+	mov	x, 33
+	bne	fail3, t, x
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 4.5
+	dbne	fail4, dv, dx
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 5.5
+	dbne	fail4, dv, dx
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 6.5
+	dbne	fail4, dv, dx
+	va_arg	p, va, d:0
+	dmov	dv, d:0(p)
+	dmov	dx, 7.5
+	dbne	fail4, dv, dx
+	va_block_arg	bs2, va, 999, 0
+	mov	t, i8:456(bs2)
+	mov	x, 78
+	bne	fail5, t, x
+	va_arg	p, va, ld:0
+	ldmov	lv, ld:0(p)
+	ldmov	lx, 11.5L
+	ldbne	fail6, lv, lx
+	va_end	va
+	ret	0
+fail1:	ret	1
+fail2:	ret	2
+fail3:	ret	3
+fail4:	ret	4
+fail5:	ret	5
+fail6:	ret	6
+	endfunc
+main:	func	i64
+	local	i64:a, i64:r, i64:t, i64:v1, i64:v2, i64:v3, ld:c1, ld:c2
+	local	d:d1, d:d2, d:d3, d:d4
+	alloca	a, 1000
+	mov	t, 77
+	mov	i8:123(a), t
+	mov	t, 78
+	mov	i8:456(a), t
+	mov	v1, 11
+	mov	v2, 22
+	ldmov	c1, 2.5L
+	mov	v3, 33
+	dmov	d1, 4.5
+	dmov	d2, 5.5
+	dmov	d3, 6.5
+	dmov	d4, 7.5
+	ldmov	c2, 11.5L
+	call	pv, vf, r, v1, v2, c1, blk:999(a), v3, d1, d2, d3, d4, blk:999(a), c2
+	bne	fail, r, 0
+	ret	0
+fail:	ret	r
+	endfunc
+	export	main
+	endmodule

--- a/mir-gen-aarch64.c
+++ b/mir-gen-aarch64.c
@@ -362,15 +362,22 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
         }
         continue;
       }
-      gen_blk_mov (gen_ctx, call_insn, blk_offset, SP_HARD_REG, 0, arg_op.u.var_mem.base, qwords,
-                   int_arg_num);
+      /* Pass by reference.  The copy and the address computation must stay
+         BEFORE all the argument hard reg loads: for qwords > 16 the copy is
+         a call to mir.blk_mov, which would clobber argument values already
+         loaded into caller-saved regs (v0-v7, x0-x7) if emitted next to the
+         call insn, so no save_regs band-aid can make that placement work.
+         Advance curr_prev_call_insn to the ADD itself so several block args
+         keep this prologue region contiguous.  */
+      MIR_reg_t blk_base_reg = arg_op.u.var_mem.base;
       arg_op = _MIR_new_var_op (ctx, gen_new_temp_reg (gen_ctx, MIR_T_I64, func));
       gen_assert (curr_prev_call_insn
                   != NULL); /* call_insn should not be 1st after simplification */
       new_insn = MIR_new_insn (gen_ctx->ctx, MIR_ADD, arg_op, _MIR_new_var_op (ctx, SP_HARD_REG),
                                MIR_new_int_op (ctx, blk_offset));
       gen_add_insn_after (gen_ctx, curr_prev_call_insn, new_insn);
-      curr_prev_call_insn = DLIST_NEXT (MIR_insn_t, new_insn);
+      gen_blk_mov (gen_ctx, new_insn, blk_offset, SP_HARD_REG, 0, blk_base_reg, qwords, 0);
+      curr_prev_call_insn = new_insn;
       blk_offset += qwords * 8;
     }
     if ((arg_reg = get_arg_reg (type, &int_arg_num, &fp_arg_num, &new_insn_code)) != MIR_NON_VAR) {

--- a/mir-gen-ppc64.c
+++ b/mir-gen-ppc64.c
@@ -205,6 +205,7 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
   MIR_op_t arg_op, temp_op, arg_reg_op, ret_reg_op, mem_op;
   MIR_insn_code_t new_insn_code, ext_code;
   MIR_insn_t new_insn, ext_insn;
+  MIR_insn_t prev_call_insn = DLIST_PREV (MIR_insn_t, call_insn);
 
   if (call_insn->code == MIR_INLINE) call_insn->code = MIR_CALL;
   if (proto->args == NULL) {
@@ -290,9 +291,19 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
                  _MIR_new_var_mem_op (ctx, MIR_T_I64, disp, arg_op.u.mem.base, MIR_NON_VAR, 1));
         setup_call_hard_reg_args (gen_ctx, call_insn, R3_HARD_REG + n_iregs);
       }
-      if (qwords > 0)
-        gen_blk_mov (gen_ctx, call_insn, mem_size + PPC64_STACK_HEADER_SIZE, SP_HARD_REG, disp,
-                     arg_op.u.mem.base, qwords, n_iregs);
+      if (qwords > 0) {
+        /* The copy of the block tail must happen BEFORE all the argument
+           hard reg loads: for qwords > 16 it is a call to mir.blk_mov, which
+           would clobber argument values already loaded into caller-saved
+           regs (f1-f13, r3-r10) if emitted next to the call insn.  Anchoring
+           at the insn following prev_call_insn puts it ahead of every arg
+           load emitted so far (SP is fixed here: the param area is part of
+           the frame).  */
+        gen_assert (prev_call_insn != NULL); /* call_insn should not be 1st */
+        gen_blk_mov (gen_ctx, DLIST_NEXT (MIR_insn_t, prev_call_insn),
+                     mem_size + PPC64_STACK_HEADER_SIZE, SP_HARD_REG, disp, arg_op.u.mem.base,
+                     qwords, 0);
+      }
       mem_size += qwords * 8;
       n_iregs += qwords;
       continue;

--- a/mir-gen-riscv64.c
+++ b/mir-gen-riscv64.c
@@ -256,7 +256,7 @@ static void gen_blk_mov (gen_ctx_t gen_ctx, MIR_insn_t anchor, size_t to_disp,
   if (save_regs > 1)
     gen_mov (gen_ctx, anchor, MIR_MOV, _MIR_new_var_op (ctx, A1_HARD_REG), treg_op2);
   if (save_regs > 2)
-    gen_mov (gen_ctx, anchor, MIR_MOV, _MIR_new_var_op (ctx, R2_HARD_REG), treg_op3);
+    gen_mov (gen_ctx, anchor, MIR_MOV, _MIR_new_var_op (ctx, A2_HARD_REG), treg_op3);
 }
 
 #define FMVXW_CODE 0
@@ -388,16 +388,22 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
         }
         continue;
       }
-      /* Put on stack and pass the address: */
-      gen_blk_mov (gen_ctx, call_insn, blk_offset, SP_HARD_REG, arg_op.u.mem.base, qwords,
-                   int_arg_num);
+      /* Put on stack and pass the address.  The copy and the address
+         computation must stay BEFORE all the argument hard reg loads: for
+         qwords > 16 the copy is a call to mir.blk_mov, which would clobber
+         argument values already loaded into caller-saved regs (fa0-fa7,
+         a0-a7) if emitted next to the call insn.  Advance
+         curr_prev_call_insn to the ADD itself so several block args keep
+         this prologue region contiguous.  */
+      MIR_reg_t blk_base_reg = arg_op.u.mem.base;
       arg_op = _MIR_new_var_op (ctx, gen_new_temp_reg (gen_ctx, MIR_T_I64, func));
       gen_assert (curr_prev_call_insn
                   != NULL); /* call_insn should not be 1st after simplification */
       new_insn = MIR_new_insn (gen_ctx->ctx, MIR_ADD, arg_op, _MIR_new_var_op (ctx, SP_HARD_REG),
                                MIR_new_int_op (ctx, blk_offset));
       gen_add_insn_after (gen_ctx, curr_prev_call_insn, new_insn);
-      curr_prev_call_insn = DLIST_NEXT (MIR_insn_t, new_insn);
+      gen_blk_mov (gen_ctx, new_insn, blk_offset, SP_HARD_REG, blk_base_reg, qwords, 0);
+      curr_prev_call_insn = new_insn;
       blk_offset += qwords * 8;
     }
     if ((arg_reg

--- a/mir-gen-s390x.c
+++ b/mir-gen-s390x.c
@@ -226,6 +226,7 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
   MIR_op_t arg_op, temp_op, arg_reg_op, ret_op, mem_op, ret_val_op, call_res_op;
   MIR_insn_code_t new_insn_code, ext_code;
   MIR_insn_t new_insn, ext_insn;
+  MIR_insn_t prev_call_insn = DLIST_PREV (MIR_insn_t, call_insn);
 
   if (call_insn->code == MIR_INLINE) call_insn->code = MIR_CALL;
   if (proto->args == NULL) {
@@ -316,9 +317,17 @@ static void machinize_call (gen_ctx_t gen_ctx, MIR_insn_t call_insn) {
                                         SP_HARD_REG, MIR_NON_VAR, 1);
           gen_mov (gen_ctx, call_insn, MIR_LDMOV, mem_op, arg_op);
         } else {
+          /* The copy must happen BEFORE all the argument hard reg loads: for
+             qwords > 16 it is a call to mir.blk_mov, which would clobber
+             argument values already loaded into caller-saved regs (f0-f6,
+             r2-r6) if emitted next to the call insn.  Anchoring at the insn
+             following prev_call_insn puts it ahead of every arg load emitted
+             so far (SP is fixed here: the value area is part of the frame).  */
           qwords = (arg_op.u.mem.disp + 7) / 8;
-          gen_blk_mov (gen_ctx, call_insn, S390X_STACK_HEADER_SIZE + blk_ld_value_disp, SP_HARD_REG,
-                       0, arg_op.u.mem.base, qwords, n_iregs);
+          gen_assert (prev_call_insn != NULL); /* call_insn should not be 1st */
+          gen_blk_mov (gen_ctx, DLIST_NEXT (MIR_insn_t, prev_call_insn),
+                       S390X_STACK_HEADER_SIZE + blk_ld_value_disp, SP_HARD_REG, 0,
+                       arg_op.u.mem.base, qwords, 0);
         }
       }
       arg_op = _MIR_new_var_op (ctx, gen_new_temp_reg (gen_ctx, MIR_T_I64, func));


### PR DESCRIPTION
`machinize_call` emitted the copy of a block argument that does not fit registers (by reference on aarch64/riscv64, into the frame's value/param area on s390x/ppc64) immediately before the call insn — i.e. after preceding arguments had already been loaded into their hard registers. For blocks over 16 qwords that copy is a call to `mir.blk_mov`, with only the first three int arg regs saved/restored around it, so:

* argument values already sitting in caller-saved registers (all FP arg regs, and int arg regs past the first three) could be physically clobbered by the `mir.blk_mov` call, and
* the register allocator, correctly treating the intervening call as clobbering caller-saved registers, could reuse those argument registers for temporaries living across it.

On riscv64 the band-aid itself was also broken: the `save_regs > 2` restore in `gen_blk_mov` wrote the saved value into `R2_HARD_REG` — the stack pointer — instead of `A2_HARD_REG`, crashing any call with a 129+ byte block arg after three int args (evidence this path never ran there).

Found via a C-to-MIR JIT frontend (slimcc) on aarch64: a variadic call passing `long double, 999-byte struct, int, 4 doubles, struct, long double` after two named ints read the first `long double` vararg as the *last* one's value, the int vararg as a stale copy size, and the doubles as 0 — on both glibc and musl.

The fix emits the copy in the insn region before all argument hard reg loads. On aarch64/riscv64 it sits next to the address computation that already lived there (also advancing `curr_prev_call_insn` to the inserted ADD itself rather than `DLIST_NEXT` of it, which pointed at the first argument load and sent a second block argument's insns into the middle of the loads). On s390x/ppc64 the frames are fixed (no per-call SP adjustment), so the copy is simply anchored at the insn following `prev_call_insn`. No save/restore is needed in any of these placements.

Tests:

* `c-tests/mir/big-blk-arg2.mir` — models the frontend's emission (typed FP temps live across the copies). On unfixed builds: aarch64 returns 1 (first double vararg misread), riscv64 crashes (the sp-restore typo), s390x returns 1; passes with the fix on all targets, and `-ei` is unaffected throughout as the interpreter doesn't machinize. The two `va_block_arg` reads deliberately use distinct dest registers (sharing one crashes gen's `copy_prop` — separate pre-existing bug, reported with reproducers in #441), and the varargs are deliberately unnamed in the proto (riscv64 passes variadic FP args in GPRs, so naming them changes their register class).
* `c-tests/mir/big-blk-arg.mir` — simpler named-args variant as a canary for the new insertion scheme.

c2mir cannot serve as a C-level regression test here: it lowers large aggregate arguments itself and never emits > 2 qword block call args.

Validation:

* aarch64: full `make test` green on Ubuntu 24.04 (gcc 13) and, with the std-libs change from #435 applied, on Alpine/musl; the new test fails at the base commit and passes fixed, all execution modes.
* x86_64: full `make test` green; the new tests pass in all modes (x86-64 was not affected — its copies use inline moves/MOVDQA).
* riscv64, s390x, ppc64le: cross-built c2m (gcc 13, `-static`) at the base commit and at this branch, and ran every `c-tests/mir/*.mir` under qemu-user in `-eg` for both builds. The only behavioral deltas across the whole set are the new test going crash→pass (riscv64) and fail→pass (s390x). ppc64le passes the test both ways — its larger callee-saved FP file happens to hide this shape — so the ppc64 change is prophylactic, justified by inspection (identical exposed pattern).

Two further riscv64-specific observations from the qemu runs, unrelated to this fix and not addressed here: long-double varargs are misread even with the fix, and protos that *name* variadic args assign them FP registers while a callee's `va_arg` reads GPRs.
