### PR TITLE
Fix non-deterministic binary output for long double constants

### DIFF
--- a/mir.c
+++ b/mir.c
@@ -4688,7 +4688,19 @@ static size_t put_ldouble (MIR_context_t ctx, writer_func_t writer, long double 
   size_t len;
 
   if (writer == NULL) return 0;
+  /* Zero the whole union first: an 80-bit long double occupies only 10 of the
+     16 bytes, so u.ld = ld leaves the 6 padding bytes uninitialized — writing
+     them makes binary MIR non-deterministic (the decoder reads back only the
+     valid bits, so content matches but raw bytes vary, breaking the bootstrap
+     self-consistency test). */
+  u.u[0] = u.u[1] = 0;
   u.ld = ld;
+#if defined(__i386__) || defined(__x86_64__)
+  /* x86 80-bit extended long double occupies only 10 of the 16 bytes; the
+     assignment may still copy the source's 6 padding bytes (e.g. via a 16-byte
+     SSE move), so mask to the meaningful 80 bits (bytes 0-9) for determinism. */
+  u.u[1] &= 0xffffULL;
+#endif
   len = put_uint (ctx, writer, u.u[0], sizeof (uint64_t));
   return put_uint (ctx, writer, u.u[1], sizeof (uint64_t)) + len;
 }


### PR DESCRIPTION
`put_ldouble` serializes a `long double` by writing both 64-bit halves of a `union { uint64_t u[2]; long double ld; }` into the binary MIR stream. On x86 an 80-bit extended `long double` occupies only 10 of the 16 union bytes, so `u.ld = ld` leaves the 6 high padding bytes uninitialized — and the assignment can even copy the *source's* padding via a 16-byte SSE move. Those garbage bytes are emitted, so `c2m -c` output is **non-deterministic run-to-run**.

The decoder reads back only the valid bits, so the decoded value is unaffected and functional tests pass — but byte-for-byte reproducibility of `.bmir` artifacts is broken.

## Fix

Zero the union before the assignment, and on x86 mask `u.u[1]` to its meaningful low 16 bits, giving a stable encoding. No effect on the decoded value or on non-x86 targets.

## Reproducer

```sh
printf 'long double a(void){return 3.14159265358979323846L;}\n' > ld.c
for i in 1 2 3; do ./c2m -c ld.c -o out$i.bmir; sha256sum out$i.bmir; done
```

`master` (x86-64) prints three different hashes; with the fix all three are identical.

Fixes #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
