### PR TITLE
Treat a string-literal address as a constant address at any scope

### DIFF
--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -7514,7 +7514,11 @@ static int check_const_addr_p (c2m_ctx_t c2m_ctx, node_t r, node_t *base, mir_ll
     *base = r;
     *offset = 0;
     *deref = 0;
-    return curr_scope == top_scope;
+    /* A string literal has static storage duration at ANY scope (C11
+       6.4.5p6), so its address is a valid address constant in a static
+       initializer even inside a function.  The static-init data emitter
+       handles an N_STR base at any scope (get_string_data). */
+    return TRUE;
   case N_LABEL_ADDR:
     *base = r;
     *offset = 0;


### PR DESCRIPTION
`check_const_addr_p` returned `curr_scope == top_scope` for an `N_STR` base, so a (possibly computed) string-literal address used to initialize a **block-scope `static`** was rejected as *"initializer of non-auto or thread local object should be a constant expression or address"*.

A string literal has static storage duration at any scope (C11 6.4.5p6), so its address is always a valid address constant — and the static-init data emitter already handles an `N_STR` base at any scope (`get_string_data`). The fix returns `TRUE`.

## Reproducer (gcc PR middle-end/53084)

```c
extern void abort (void);
__attribute__((noinline, noclone)) void bar (const char *p) {
  if (p[0] != 'o' || p[1] != 'o' || p[2]) abort ();
}
int main () {
  static const char *const foo[] = {"foo" + 1};
  bar (foo[0]);
  return 0;
}
```

`master`: `./c2m pr53084.c -ei` (and `-eg`) error with the message above. With the fix both compile and exit 0.

Fixes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
