### PR TITLE
Fix va_block_arg crashes/miscompile with a shared or missing destination (#441)

### DIFF
--- a/c-tests/mir/issue441.mir
+++ b/c-tests/mir/issue441.mir
@@ -1,0 +1,20 @@
+mcp:	module
+p:	proto	i64, i64:a0, ...
+f:	func	i64, i64:i0, ...
+	local	i64:va, i64:bs
+	alloca	va, 48
+	alloca	bs, 16
+	va_start	va
+	va_block_arg	bs, va, 16, 0
+	va_block_arg	bs, va, 16, 0
+	va_end	va
+	ret	0
+	endfunc
+main:	func	i64
+	local	i64:a, i64:r
+	alloca	a, 16
+	call	p, f, r, 1, blk:16(a), blk:16(a)
+	ret	r
+	endfunc
+	export	main
+	endmodule

--- a/c-tests/new/issue441.c
+++ b/c-tests/new/issue441.c
@@ -1,0 +1,17 @@
+/* PR #441: a struct/union va_arg used directly as an rvalue must get real
+   storage (it was written to NULL), and two va_block_arg insns must not be
+   CSE'd by GVN (op 0 is an input address, not a def). */
+#include <stdarg.h>
+struct S { char c[999]; };
+static int f (int i, ...) {
+  va_list ap;
+  va_start (ap, i);
+  int a = va_arg (ap, struct S).c[0];
+  int b = va_arg (ap, struct S).c[1];
+  va_end (ap);
+  return a + b;
+}
+int main (void) {
+  struct S s = {{21, 21}};
+  return f (1, s, s) == 42 ? 0 : 1;
+}

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -12865,9 +12865,15 @@ static op_t gen (c2m_ctx_t c2m_ctx, node_t r, MIR_label_t true_label, MIR_label_
       }
       if (type->mode == TM_STRUCT || type->mode == TM_UNION) {
         if (desirable_dest == NULL) {
+          /* A struct/union va_arg used as an rvalue (no destination object)
+             still needs storage to receive the aggregate; allocate a frame
+             temporary and use its address.  Previously this was a stub that
+             moved 0 into res, so va_block_arg wrote the aggregate to address
+             0 (NULL) -- a miscompile / runtime crash. */
           res = get_new_temp (c2m_ctx, MIR_T_I64);
           MIR_append_insn (ctx, curr_func,
-                           MIR_new_insn (ctx, MIR_MOV, res.mir_op, MIR_new_int_op (ctx, 0)));
+                           MIR_new_insn (ctx, MIR_ALLOCA, res.mir_op,
+                                         MIR_new_int_op (ctx, type_size (c2m_ctx, type))));
         } else {
           assert (desirable_dest->mir_op.mode == MIR_OP_MEM);
           res = mem_to_address (c2m_ctx, *desirable_dest, TRUE);
@@ -12877,7 +12883,10 @@ static op_t gen (c2m_ctx_t c2m_ctx, node_t r, MIR_label_t true_label, MIR_label_
                                        MIR_new_int_op (ctx, type_size (c2m_ctx, type)),
                                        MIR_new_int_op (ctx, target_get_blk_type (c2m_ctx, type)
                                                               - MIR_T_BLK)));
-        if (desirable_dest != NULL) res = *desirable_dest;
+        if (desirable_dest != NULL)
+          res = *desirable_dest;
+        else /* present the freshly allocated buffer as the aggregate lvalue */
+          res.mir_op = MIR_new_mem_op (ctx, MIR_T_UNDEF, 0, res.mir_op.u.reg, 0, 1);
       } else {
         MIR_append_insn (ctx, curr_func,
                          MIR_new_insn (ctx, MIR_VA_ARG, op1.mir_op, op2.mir_op,

--- a/mir-gen.c
+++ b/mir-gen.c
@@ -3805,7 +3805,8 @@ static int fixed_place_insn_p (MIR_insn_t insn) {
   return (insn->code == MIR_RET || insn->code == MIR_JRET || insn->code == MIR_SWITCH
           || insn->code == MIR_LABEL || MIR_call_code_p (insn->code) || insn->code == MIR_ALLOCA
           || insn->code == MIR_BSTART || insn->code == MIR_BEND || insn->code == MIR_VA_START
-          || insn->code == MIR_VA_ARG || insn->code == MIR_VA_END);
+          || insn->code == MIR_VA_ARG || insn->code == MIR_VA_BLOCK_ARG
+          || insn->code == MIR_VA_END);
 }
 
 static int gvn_insn_p (MIR_insn_t insn) { return !fixed_place_insn_p (insn); }


### PR DESCRIPTION
#441 turned out to be two distinct bugs — one in the generator (the path that bites direct-MIR frontends like slimcc) and one in c2mir (the `-eg` C reproducer). This fixes both.

## 1. Generator — `VA_BLOCK_ARG` is CSE'd by GVN (commit 1)

`fixed_place_insn_p` listed `MIR_VA_ARG` but not `MIR_VA_BLOCK_ARG`, so GVN value-numbered two `va_block_arg` fetches with identical operands as one movable expression and CSE'd them. The rewrite then corrupted the second insn's SSA edges (operand 0 is an *input address*, not a def), and `copy_prop` dereferenced a NULL edge → SIGSEGV. `va_block_arg` advances the `va_list` and writes memory — the same side effects that already keep `MIR_VA_ARG` fixed-place.

Fixes the **MIR reproducer** in #441, plus `gcc.c-torture/execute/strct-varg-1.c` and `920908-1.c` under the generator.

## 2. c2mir — struct `va_arg` rvalue written to NULL (commit 2)

A struct/union `va_arg` with no destination object (used directly as an rvalue, e.g. `va_arg(ap, struct S).c[0]`) hit an unfinished path that did `mov res, 0` and used that as the `va_block_arg` destination — so the aggregate was written to **address 0** and read back from a bogus base. The fix allocates a frame temporary and presents it as the result lvalue, mirroring the existing desirable-dest path.

Fixes the **C reproducer** in #441.

> Note: the temp is an `alloca`, so a struct `va_arg` rvalue *inside a loop* grows the frame (correct, but a reserved frame slot would be tighter). Happy to switch to a reserved slot if you'd prefer.

## Tests (fail before, pass after)

- `c-tests/mir/issue441.mir` — the MIR reproducer (generator path)
- `c-tests/new/issue441.c` — the C reproducer (c2mir path), auto-run across interp/gen/O0/O1/O3

On `master`: `issue441.c` → `Segmentation fault`. With the fix both are `OK`.

## Validation

Full `make test` green — `Tests 1076, Success tests 2152` (+2 = the new tests), all 6 bootstrap variants Passed, zero regressions.

Fixes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
