### PR TITLE
Give a zero-length array member its running offset, not 0

### DIFF
--- a/c-tests/new/issue450.c
+++ b/c-tests/new/issue450.c
@@ -1,0 +1,7 @@
+/* PR #450: a zero-length array member must sit at the running offset,
+   not 0 (which would alias the preceding member). */
+struct S { unsigned char n[1]; char a[0]; };
+int main (void) {
+  struct S s;
+  return ((char *) s.a - (char *) &s) == 1 ? 0 : 1;
+}

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -6260,7 +6260,22 @@ static void set_type_layout (c2m_ctx_t c2m_ctx, struct type *type) {
 
           if (anon_process_p) update_members_offset (decl->decl_spec.type, MIR_SIZE_MAX);
           set_type_layout (c2m_ctx, decl->decl_spec.type);
-          if ((member_size = type_size (c2m_ctx, decl->decl_spec.type)) == 0) continue;
+          if ((member_size = type_size (c2m_ctx, decl->decl_spec.type)) == 0) {
+            /* A zero-size member -- a GNU zero-length array, e.g. `char a[0];`
+               -- occupies no storage and does not advance the layout, but it
+               still has a position: GCC places it at the current offset (just
+               past the preceding members).  `continue`-ing left decl->offset at
+               its default 0, so &s.a aliased the first member.  Set its offset
+               to the current (aligned) running offset; do not grow the type. */
+            member_align = type_align (decl->decl_spec.type);
+            if (decl->decl_spec.align > member_align) member_align = decl->decl_spec.align;
+            decl->offset = type->mode == TM_UNION
+                             ? 0
+                             : (overall_size + member_align - 1) / member_align * member_align;
+            decl->bit_offset = -1;
+            decl->width = -1;
+            continue;
+          }
           member_align = type_align (decl->decl_spec.type);
           bits
             = width->code == N_IGNORE || !(expr = width->attr)->const_p ? -1 : (int) expr->c.u_val;


### PR DESCRIPTION
`set_type_layout` skips any member whose `type_size` is 0 (`continue`), so a GNU zero-length array member never has its offset assigned and keeps the declaration default of **0**, aliasing the preceding member. GCC places a zero-length array at the current (aligned) offset, just past the preceding members.

## Fix

For a zero-size member, set `decl->offset` to the current running offset (0 in a union) without growing the type, instead of skipping it. Only zero-size members are affected; C99 flexible array members (`a[]`) go through a separate path and are unchanged.

## Reproducer

```c
struct S { unsigned char n[1]; char a[0]; };
int main (void) {
  struct S s;
  return ((char *) s.a - (char *) &s) == 1 ? 0 : 1;  /* gcc: 1; got: 0 */
}
```

`master`: `-ei`/`-eg` return 1 (`s.a` overlaps `s.n`). With the fix, 0. `gcc.c-torture/execute/zerolen-1.c` also aborts on `master` and passes with the fix. Test added as `c-tests/new/issue450.c`.

Fixes #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
