### PR TITLE
Fix out-of-SSA lost-copy hazard for self-predecessor blocks

### DIFF
--- a/c-tests/new/issue454.c
+++ b/c-tests/new/issue454.c
@@ -1,0 +1,8 @@
+/* PR #454: out-of-SSA lost-copy hazard for a self-loop block -- the
+   condition must see this iteration's value, not the next. */
+extern void abort (void);
+int main (void) {
+  int n = 0, i = 5;
+  while (i-- > 0) n++;
+  return n == 5 ? 0 : 1;
+}

--- a/mir-gen.c
+++ b/mir-gen.c
@@ -2766,6 +2766,14 @@ static void make_conventional_ssa (gen_ctx_t gen_ctx) { /* requires life info */
       }
       for (se = insn->ops[0].data; se != NULL; se = se->next_use)
         if (se->use->bb != bb) break;
+      if (se == NULL) /* lost-copy hazard: a self-loop puts a phi-input copy of dest_var at the
+                         end of this bb (before the tail branch), so a use renamed to dest_var
+                         at/after that point would read the next iteration's value */
+        for (e = DLIST_HEAD (in_edge_t, bb->in_edges); e != NULL; e = DLIST_NEXT (in_edge_t, e))
+          if (e->src == bb) {
+            se = insn->ops[0].data;
+            break;
+          }
       if (se == NULL) { /* we should do this only after adding moves at the end of bbs */
         /* r=phi(...), all r uses in the same bb: change new_r = phi(...) and all uses by new_r */
         insn->ops[0].u.var = dest_var;


### PR DESCRIPTION
`make_conventional_ssa`'s same-bb fast path renames a phi result and all its uses to the congruence-class register. When the phi's block is **its own predecessor** (self-loop), the back-edge phi-input copy is inserted at the end of that block, *before* the tail branch — so a renamed use in the branch reads the **next** iteration's value (classic lost-copy). A `while (i-- > 0)` loop testing the phi var directly runs one iteration short.

## Fix

Take the slow path (`mov var, dest_var` after the phi; uses keep `var`) whenever the block is a self-predecessor.

## Reproducer (fail before, pass after)

```c
extern void abort (void);
int main (void) {
  int n = 0, i = 5;
  while (i-- > 0) n++;
  return n == 5 ? 0 : 1;
}
```

`master`: `./c2m repro.c -eg` returns 1 (n==4). With the fix, 0. `gcc.c-torture/execute/pr43236.c` also aborts under the generator on `master` and passes with the fix. Test added as `c-tests/new/issue454.c`.

Fixes #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
