### PR TITLE
Sign/zero-extend a narrow integer register value in force_val

### DIFF
--- a/c-tests/new/issue458.c
+++ b/c-tests/new/issue458.c
@@ -1,0 +1,22 @@
+static void set_uchar (unsigned char *p) { *p = 255; }
+static void set_schar (signed char *p) { *p = -3; }
+static void set_ushort (unsigned short *p) { *p = 65535; }
+static void set_short (short *p) { *p = -2; }
+
+int main (void) {
+  unsigned char uc;
+  signed char sc;
+  unsigned short us;
+  short ss;
+
+  set_uchar (&uc);
+  set_schar (&sc);
+  set_ushort (&us);
+  set_short (&ss);
+
+  if (uc != 255) return 1;
+  if (sc != -3) return 2;
+  if (us != 65535) return 3;
+  if (ss != -2) return 4;
+  return 0;
+}

--- a/c2mir/c2mir.c
+++ b/c2mir/c2mir.c
@@ -10800,10 +10800,17 @@ static op_t force_val (c2m_ctx_t c2m_ctx, op_t op, int arr_p) {
   MIR_context_t ctx = c2m_ctx->ctx;
   op_t temp_op;
   int sh;
+  MIR_type_t t;
 
   if (arr_p && op.mir_op.mode == MIR_OP_MEM) {
     /* an array -- use a pointer: */
     return mem_to_address (c2m_ctx, op, FALSE);
+  }
+  if (op.decl != NULL && op.mir_op.mode == MIR_OP_REG
+      && integer_type_p (op.decl->decl_spec.type)) {
+    t = get_mir_type (c2m_ctx, op.decl->decl_spec.type);
+    if (t == MIR_T_I8 || t == MIR_T_U8 || t == MIR_T_I16 || t == MIR_T_U16)
+      return cast (c2m_ctx, op, t, TRUE);
   }
   if (op.decl == NULL || op.decl->bit_offset < 0) return op;
   assert (op.mir_op.mode == MIR_OP_MEM);


### PR DESCRIPTION
`force_val` does not sign/zero-extend the value of a narrow integer (`i8`/`u8`/`i16`/`u16`) variable held in a register, so reading an address-taken `signed char` / `short` (etc.) can yield a non-extended value under the interpreter.

## Fix

In `force_val`, when the operand is a register of a narrow integer type, cast it to that type so the value is properly sign/zero-extended.

## Reproducer (fail before, pass after)

```c
static void set_schar (signed char *p) { *p = -3; }
static void set_ushort (unsigned short *p) { *p = 65535; }
int main (void) {
  signed char sc; unsigned short us;
  set_schar (&sc); set_ushort (&us);
  if (sc != -3) return 2;
  if (us != 65535) return 3;
  return 0;
}
```

`master`: `./c2m repro.c -ei` returns 2 (`sc` not sign-extended). With the fix, 0. Test added as `c-tests/new/issue458.c`.

Fixes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
